### PR TITLE
German keymap + ErgoDox keymaps

### DIFF
--- a/keyboard/ergodox_ez/keymaps/keymap_german.c
+++ b/keyboard/ergodox_ez/keymaps/keymap_german.c
@@ -1,0 +1,185 @@
+#include "ergodox_ez.h"
+#include "debug.h"
+#include "action_layer.h"
+#include "keymap_extras/keymap_german.h"
+
+// Layer names
+#define BASE 0 // default layer
+#define SYMB 1 // symbol layer
+#define MDIA 2 // media keys
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |   ^    |   1  |   2  |   3  |   4  |   5  | Play |           | Next |   6  |   7  |   8  |   9  |   0  |   ß    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |  Del   |   Q  |   W  |   E  |   R  |   T  |  L1  |           |  L2  |   Z  |   U  |   I  |   O  |   P  |   Ü    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |  Caps  |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |   Ö  |  Ä/L2  |
+ * |--------+------+------+------+------+------| Hyper|           | Meh  |------+------+------+------+------+--------|
+ * | LShift |   Y  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |-/Ctrl| RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   | </L1 |#/Ctrl|   ´  |   -  |   +  |                                       | Right| Down |  Up  | Left | ~L1  |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        | App  | LGui |       | Alt  |Ctrl/Esc|
+ *                                 ,------+------+------|       |------+--------+------.
+ *                                 |      |      | Home |       | PgUp |        |      |
+ *                                 | Space|Backsp|------|       |------|  Tab   |Enter |
+ *                                 |      |ace   | End  |       | PgDn |        |      |
+ *                                 `--------------------'       `----------------------'
+ */
+// If it accepts an argument (i.e, is a function), it doesn't need KC_.
+// Otherwise, it needs KC_*
+[BASE] = KEYMAP(  // layer 0 : default
+        // left hand
+        KC_CIRC,         KC_1,           KC_2,     KC_3,     KC_4,     KC_5,   KC_MPLY,
+        KC_DELT,         KC_Q,           KC_W,     KC_E,     KC_R,     KC_T,   TG(1),
+        KC_CAPS,         KC_A,           KC_S,     KC_D,     KC_F,     KC_G,
+        KC_LSFT,         DE_Y,           KC_X,     KC_C,     KC_V,     KC_B,   ALL_T(KC_NO),
+        LT(SYMB,DE_LESS),CTL_T(DE_HASH), DE_ACUT,  DE_MINS,  DE_PLUS,
+                                               ALT_T(KC_APP), KC_LGUI,
+                                                              KC_HOME,
+                                               KC_SPC,KC_BSPC,KC_END,
+        // right hand
+        KC_MNXT,     KC_6,   KC_7,    KC_8,    KC_9,   KC_0,             KC_MINS,
+        TG(2),       DE_Z,   KC_U,    KC_I,    KC_O,   KC_P,             DE_UE,
+                     KC_H,   KC_J,    KC_K,    KC_L,   DE_OE,            LT(MDIA,DE_AE),
+        MEH_T(KC_NO),KC_N,   KC_M,    KC_COMM, KC_DOT, CTL_T(DE_MINS),   KC_RSFT,
+                             KC_LEFT, KC_DOWN, KC_UP,  KC_RGHT,          KC_FN1,
+        KC_LALT,CTL_T(KC_ESC),
+        KC_PGUP,
+        KC_PGDN,KC_TAB, KC_ENT
+    ),
+/* Keymap 1: Symbol Layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |   !  |   @  |   {  |   }  |   |  |      |           |      |   Up |   7  |   8  |   9  |   *  |   F12  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   #  |   $  |   (  |   )  |   `  |------|           |------| Down |   4  |   5  |   6  |   +  |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |   &  |   1  |   2  |   3  |   \  |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |      |    . |   0  |   =  |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |      |
+ *                                 |      |      |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// SYMBOLS
+[SYMB] = KEYMAP(
+       // left hand
+       KC_TRNS,KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
+       KC_TRNS,DE_EXLM,DE_AT,  DE_LCBR,DE_RCBR,DE_PIPE,KC_TRNS,
+       KC_TRNS,DE_HASH,DE_DLR, DE_LPRN,DE_RPRN,DE_GRV,
+       KC_TRNS,DE_PERC,DE_CIRC,DE_LBRC,DE_RBRC,DE_TILD,KC_TRNS,
+       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+                                       KC_TRNS,KC_TRNS,
+                                               KC_TRNS,
+                               KC_TRNS,KC_TRNS,KC_TRNS,
+       // right hand
+       KC_TRNS, KC_F6,   KC_F7,  KC_F8,   KC_F9,   KC_F10,  KC_F11,
+       KC_TRNS, KC_UP,   KC_7,   KC_8,    KC_9,    DE_ASTR, KC_F12,
+                KC_DOWN, KC_4,   KC_5,    KC_6,    DE_PLUS, KC_TRNS,
+       KC_TRNS, DE_AMPR, KC_1,   KC_2,    KC_3,    DE_BSLS, KC_TRNS,
+                         KC_TRNS,KC_DOT,  KC_0,    DE_EQL,  KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS
+),
+/* Keymap 2: Media and mouse keys
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |      | Lclk | MsUp | Rclk |      |      |           |      |      |VolDwn| Mute |VolUp |      |   F12  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        | Btn4 |MsLeft|MsDown|MsRght| Btn5 |------|           |------|      | Prev | Stop | Play | Next |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |WhRght|WhDown| WhUp |WhLeft|WhClk |      |           |      |BwSrch|BwBack|BwHome|BwRefr|BwFwd |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |MsAcl0|MsAcl1|MsAcl2|                                       |      |      |      |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |Brwser|Brwser|
+ *                                 | Lclk | Rclk |------|       |------|Back  |Forwd |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// MEDIA AND MOUSE
+[MDIA] = KEYMAP(
+       KC_TRNS, KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_BTN1, KC_MS_U, KC_BTN2, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_BTN4, KC_MS_L, KC_MS_D, KC_MS_R, KC_BTN5,
+       KC_TRNS, KC_WH_L, KC_WH_D, KC_WH_U, KC_WH_R, KC_BTN3, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_ACL0, KC_ACL1, KC_ACL2,
+                                           KC_TRNS, KC_TRNS,
+                                                    KC_TRNS,
+                                  KC_BTN1, KC_BTN2, KC_TRNS,
+    // right hand
+       KC_TRNS, KC_F6  , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11,
+       KC_TRNS, KC_TRNS, KC_VOLD, KC_MUTE, KC_VOLU, KC_TRNS, KC_F12,
+                KC_TRNS, KC_MPRV, KC_MSTP, KC_MPLY, KC_MNXT, KC_TRNS,
+       KC_TRNS, KC_WSCH, KC_WBAK, KC_WHOM, KC_WREF, KC_WFWD, KC_TRNS,
+                         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_WBAK, KC_WFWD
+),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    [1] = ACTION_LAYER_TAP_TOGGLE(SYMB)                // FN1 - Momentary Layer 1 (Symbols)
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+        if (record->event.pressed) {
+          register_code(KC_RSFT);
+        } else {
+          unregister_code(KC_RSFT);
+        }
+        break;
+      }
+    return MACRO_NONE;
+};
+
+// Runs just one time when the keyboard initializes.
+void * matrix_init_user(void) {
+
+};
+
+// Runs constantly in the background, in a loop.
+void * matrix_scan_user(void) {
+
+    uint8_t layer = biton32(layer_state);
+
+    ergodox_board_led_off();
+    ergodox_right_led_1_off();
+    ergodox_right_led_2_off();
+    ergodox_right_led_3_off();
+    switch (layer) {
+        case SYMB:
+            ergodox_right_led_1_on();
+            break;
+        case MDIA:
+            ergodox_right_led_2_on();
+            break;
+        default:
+            ergodox_board_led_off();
+            break;
+    }
+
+};

--- a/keyboard/ergodox_ez/keymaps/keymap_software_neo2.c
+++ b/keyboard/ergodox_ez/keymaps/keymap_software_neo2.c
@@ -1,0 +1,139 @@
+#include "ergodox_ez.h"
+#include "debug.h"
+#include "action_layer.h"
+#include "keymap_extras/keymap_neo2.h"
+
+// Layer names
+#define BASE 0 // default layer
+#define MDIA 1 // media keys
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |   ^    |   1  |   2  |   3  |   4  |   5  | Play |           | Next |   6  |   7  |   8  |   9  |   0  |BackSpce|
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |  Del   |   X  |   V  |   L  |   C  |   W  |  L1  |           |  L1  |   K  |   H  |   G  |   F  |   Q  |   ß    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |  Caps  |   U  |   I  |   A  |   E  |   O  |------|           |------|   S  |   N  |   R  |   T  |   D  |   Y    |
+ * |--------+------+------+------+------+------| Hyper|           | Meh  |------+------+------+------+------+--------|
+ * | LShift |Ü/Ctrl| Ö/C-S| Ä/Alt|   P  |   Z  |      |           |      |   B  |   M  |   ,  |   .  |   J  | RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |  L1  | Home | PgDn | PgUp | End  |                                       | Right| Down |  Up  | Left |  Esc  |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        | App  | LGui |       | Alt  |Ctrl/Esc|
+ *                                 ,------+------+------|       |------+--------+------.
+ *                                 |      |      |NeoL2 |       |NeoL2 |        |      |
+ *                                 | Tab  |Backsp|------|       |------|  Space |Enter |
+ *                                 |      |ace   |NeoL1 |       |NeoL1 |        |      |
+ *                                 `--------------------'       `----------------------'
+ */
+// If it accepts an argument (i.e, is a function), it doesn't need KC_.
+// Otherwise, it needs KC_*
+[BASE] = KEYMAP(  // layer 0 : default
+        // left hand
+        KC_CIRC,         KC_1,          KC_2,          KC_3,          KC_4,    KC_5,    KC_MPLY,
+        KC_DELT,         NEO_X,         NEO_V,         NEO_L,         NEO_C,   NEO_W,   TG(1),
+        KC_CAPS,         NEO_U,         NEO_I,         NEO_A,         NEO_E,   NEO_O,
+        KC_LSFT,         CTL_T(NEO_UE), C_S_T(NEO_OE), ALT_T(NEO_AE), NEO_P,   NEO_Z,   ALL_T(KC_NO),
+        DE_LESS,         KC_HOME,       KC_PGDN,        KC_PGUP,        KC_END,
+                                                ALT_T(KC_APP),KC_LGUI,
+                                                              NEO_L2_L,
+                                               KC_TAB,KC_BSPC,NEO_L1_L,
+        // right hand
+        KC_MNXT,     KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,
+        TG(1),       NEO_K,   NEO_H,   NEO_G,   NEO_F,   NEO_Q,   NEO_SS,
+                     NEO_S,   NEO_N,   NEO_R,   NEO_T,   NEO_D,   NEO_Y,
+        MEH_T(KC_NO),NEO_B,   NEO_M,   KC_COMM, KC_DOT,  NEO_J,   KC_RSFT,
+                              KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_ESC,
+        KC_LALT,CTL_T(KC_ESC),
+        NEO_L2_R,
+        NEO_L1_R,KC_SPC, KC_ENT
+    ),
+/* Keymap 1: Media and mouse keys
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |      | Lclk | MsUp | Rclk |      |      |           |      |      |VolDwn| Mute |VolUp |      |   F12  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        | Btn4 |MsLeft|MsDown|MsRght| Btn5 |------|           |------|      | Prev | Stop | Play | Next |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |WhRght|WhDown| WhUp |WhLeft|WhClk |      |           |      |BwSrch|BwBack|BwHome|BwRefr|BwFwd |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |MsAcl0|MsAcl1|MsAcl2|                                       |      |      |      |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |Brwser|Brwser|
+ *                                 | Lclk | Rclk |------|       |------|Back  |Forwd |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+// MEDIA AND MOUSE
+[MDIA] = KEYMAP(
+       KC_TRNS, KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_BTN1, KC_MS_U, KC_BTN2, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_BTN4, KC_MS_L, KC_MS_D, KC_MS_R, KC_BTN5,
+       KC_TRNS, KC_WH_L, KC_WH_D, KC_WH_U, KC_WH_R, KC_BTN3, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_ACL0, KC_ACL1, KC_ACL2,
+                                           KC_TRNS, KC_TRNS,
+                                                    KC_TRNS,
+                                  KC_BTN1, KC_BTN2, KC_TRNS,
+    // right hand
+       KC_TRNS, KC_F6  , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11,
+       KC_TRNS, KC_TRNS, KC_VOLD, KC_MUTE, KC_VOLU, KC_TRNS, KC_F12,
+                KC_TRNS, KC_MPRV, KC_MSTP, KC_MPLY, KC_MNXT, KC_TRNS,
+       KC_TRNS, KC_WSCH, KC_WBAK, KC_WHOM, KC_WREF, KC_WFWD, KC_TRNS,
+                         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       KC_TRNS,
+       KC_TRNS, KC_WBAK, KC_WFWD
+),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    /* [1] = ACTION_LAYER_TAP_TOGGLE(SYMB)                // FN1 - Momentary Layer 1 (Symbols) */
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+        if (record->event.pressed) {
+          register_code(KC_RSFT);
+        } else {
+          unregister_code(KC_RSFT);
+        }
+        break;
+      }
+    return MACRO_NONE;
+};
+
+// Runs just one time when the keyboard initializes.
+void * matrix_init_user(void) {
+
+};
+
+// Runs constantly in the background, in a loop.
+void * matrix_scan_user(void) {
+
+    uint8_t layer = biton32(layer_state);
+
+    ergodox_board_led_off();
+    ergodox_right_led_1_off();
+    ergodox_right_led_2_off();
+    ergodox_right_led_3_off();
+    switch (layer) {
+        case MDIA:
+            ergodox_right_led_2_on();
+            break;
+        default:
+            ergodox_board_led_off();
+            break;
+    }
+
+};

--- a/quantum/keymap_common.h
+++ b/quantum/keymap_common.h
@@ -191,6 +191,7 @@ extern const uint16_t fn_actions[];
 #define SFT_T(kc) MT(0x2, kc)
 #define ALT_T(kc) MT(0x4, kc)
 #define GUI_T(kc) MT(0x8, kc)
+#define C_S_T(kc) MT(0x3, kc) // Control + Shift e.g. for gnome-terminal
 #define MEH_T(kc) MT(0x7, kc) // Meh is a less hyper version of the Hyper key -- doesn't include Win or Cmd, so just alt+shift+ctrl
 #define ALL_T(kc) MT(0xF, kc) // see http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/
 

--- a/quantum/keymap_extras/keymap_german.h
+++ b/quantum/keymap_extras/keymap_german.h
@@ -1,0 +1,60 @@
+#ifndef KEYMAP_GERMAN
+#define KEYMAP_GERMAN
+
+#include "keymap_common.h"
+
+// Alt gr
+#define ALGR(kc) kc | 0x1400
+#define DE_ALGR KC_RALT
+
+// normal characters
+#define DE_Z KC_Y
+#define DE_Y KC_Z
+
+#define DE_SS KC_MINS
+#define DE_AE KC_QUOT
+#define DE_UE KC_LBRC
+#define DE_OE KC_SCLN
+
+#define DE_CIRC KC_GRAVE // accent circumflex ^ and ring °
+#define DE_ACUT KC_EQL // accent acute ´ and grave `
+#define DE_PLUS KC_RBRC // + and * and ~
+#define DE_HASH KC_BSLS // # and '
+#define DE_LESS KC_NUBS // < and > and |
+#define DE_MINS KC_SLSH // - and _
+
+// shifted characters
+#define DE_RING LSFT(DE_CIRC) // °
+#define DE_EXLM LSFT(KC_1) // !
+#define DE_DQOT LSFT(KC_2) // "
+#define DE_PARA LSFT(KC_3) // §
+#define DE_DLR  LSFT(KC_4) // $
+#define DE_PERC LSFT(KC_5) // %
+#define DE_AMPR LSFT(KC_6) // &
+#define DE_SLSH LSFT(KC_7) // /
+#define DE_LPRN LSFT(KC_8) // (
+#define DE_RPRN LSFT(KC_9) // )
+#define DE_EQL  LSFT(KC_0) // =
+#define DE_QST  LSFT(DE_SS) // ?
+#define DE_GRV  LSFT(DE_ACUT) // `
+#define DE_ASTR LSFT(DE_PLUS) // *
+#define DE_QUOT LSFT(DE_HASH) // '
+#define DE_MORE LSFT(DE_LESS) // >
+#define DE_COLN LSFT(KC_DOT) // :
+#define DE_SCLN LSFT(KC_COMM) // ;
+#define DE_UNDS LSFT(DE_MINS) // _
+
+// Alt Gr-ed characters
+#define DE_SQ2 ALGR(KC_2) // ²
+#define DE_SQ3 ALGR(KC_3) // ³
+#define DE_LCBR ALGR(KC_7) // {
+#define DE_LBRC ALGR(KC_8) // [
+#define DE_RBRC ALGR(KC_9) // ]
+#define DE_RCBR ALGR(KC_0) // }
+#define DE_BSLS ALGR(DE_SS) // backslash
+#define DE_AT  ALGR(KC_Q) // @
+#define DE_EURO ALGR(KC_E) // €
+#define DE_TILD ALGR(DE_PLUS) // ~
+#define DE_PIPE ALGR(DE_LESS) // |
+
+#endif

--- a/quantum/keymap_extras/keymap_neo2.h
+++ b/quantum/keymap_extras/keymap_neo2.h
@@ -1,0 +1,44 @@
+#ifndef KEYMAP_NEO2
+#define KEYMAP_NEO2
+
+#include "keymap_common.h"
+#include "keymap_extras/keymap_german.h"
+
+#define NEO_A KC_D
+#define NEO_B KC_N
+#define NEO_C KC_R
+#define NEO_D DE_OE
+#define NEO_E KC_F
+#define NEO_F KC_O
+#define NEO_G KC_I
+#define NEO_H KC_U
+#define NEO_I KC_S
+#define NEO_J DE_MINS
+#define NEO_K DE_Z
+#define NEO_L KC_E
+#define NEO_M KC_M
+#define NEO_N KC_J
+#define NEO_O KC_G
+#define NEO_P KC_V
+#define NEO_Q KC_P
+#define NEO_R KC_K
+#define NEO_S KC_H
+#define NEO_T KC_L
+#define NEO_U KC_A
+#define NEO_V KC_W
+#define NEO_W KC_T
+#define NEO_X KC_Q
+#define NEO_Y DE_AE
+#define NEO_Z KC_B
+#define NEO_AE KC_C
+#define NEO_OE KC_X
+#define NEO_UE DE_Y
+#define NEO_SS DE_UE
+
+#define NEO_L1_L KC_CAPS
+#define NEO_L1_R DE_HASH
+
+#define NEO_L2_L DE_LESS
+#define NEO_L2_R DE_ALGR
+
+#endif


### PR DESCRIPTION
I've created a German language keymap (inspired by the French one) and a corresponding basic German ErgoDox layout based on the default one. 

I use an alternative German layout called Neo2 (http://www.neo-layout.org/). Added a language keymap and an ErgoDox layout for a "software based" (OS realized layout) Neo2.

I also added a Ctrl-Shift tap modifier which maybe useful for gnome-terminal (Ctrl-Shift-C copy, Ctrl-Shift-V paste)