### PR TITLE
Dave's custom keymap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.lst
 *.map
 *.sym
+*.swp
 tags
 *~
 build/

--- a/keyboard/ergodox_ez/ergodox_ez.c
+++ b/keyboard/ergodox_ez/ergodox_ez.c
@@ -6,12 +6,12 @@ uint8_t mcp23018_status = 0x20;
 
 __attribute__ ((weak))
 void * matrix_init_user(void) {
-
+    return NULL;
 };
 
 __attribute__ ((weak))
 void * matrix_scan_user(void) {
-
+    return NULL;
 };
 
 void * matrix_init_kb(void) {
@@ -34,16 +34,20 @@ void * matrix_init_kb(void) {
 
     ergodox_blink_all_leds();
 
-	if (matrix_init_user) {
-		(*matrix_init_user)();
-	}
+    if (matrix_init_user) {
+        (*matrix_init_user)();
+    }
+
+    return NULL;
 };
 
 void * matrix_scan_kb(void) {
 
-	if (matrix_scan_user) {
-		(*matrix_scan_user)();
-	}
+    if (matrix_scan_user) {
+        (*matrix_scan_user)();
+    }
+
+    return NULL;
 };
 
 
@@ -51,8 +55,19 @@ void ergodox_blink_all_leds(void)
 {
     ergodox_led_all_off();
     ergodox_led_all_set(LED_BRIGHTNESS_HI);
-    ergodox_led_all_on();
-    _delay_ms(333);
+    ergodox_right_led_1_on();
+    _delay_ms(50);
+    ergodox_right_led_2_on();
+    _delay_ms(50);
+    ergodox_right_led_3_on();
+    _delay_ms(50);
+    ergodox_right_led_1_off();
+    _delay_ms(50);
+    ergodox_right_led_2_off();
+    _delay_ms(50);
+    ergodox_right_led_3_off();
+    //ergodox_led_all_on();
+    //_delay_ms(333);
     ergodox_led_all_off();
 }
 

--- a/keyboard/ergodox_ez/ergodox_ez.h
+++ b/keyboard/ergodox_ez/ergodox_ez.h
@@ -34,7 +34,7 @@ void ergodox_blink_all_leds(void);
 uint8_t init_mcp23018(void);
 uint8_t ergodox_left_leds_update(void);
 
-#define LED_BRIGHTNESS_LO       31
+#define LED_BRIGHTNESS_LO       15
 #define LED_BRIGHTNESS_HI       255
 
 
@@ -42,11 +42,13 @@ inline void ergodox_board_led_on(void)      { DDRD |=  (1<<6); PORTD |=  (1<<6);
 inline void ergodox_right_led_1_on(void)    { DDRB |=  (1<<5); PORTB |=  (1<<5); }
 inline void ergodox_right_led_2_on(void)    { DDRB |=  (1<<6); PORTB |=  (1<<6); }
 inline void ergodox_right_led_3_on(void)    { DDRB |=  (1<<7); PORTB |=  (1<<7); }
+inline void ergodox_right_led_on(uint8_t led) { DDRB |= (1<<(led+4)); PORTB |= (1<<(led+4)); }
 
 inline void ergodox_board_led_off(void)     { DDRD &= ~(1<<6); PORTD &= ~(1<<6); }
 inline void ergodox_right_led_1_off(void)   { DDRB &= ~(1<<5); PORTB &= ~(1<<5); }
 inline void ergodox_right_led_2_off(void)   { DDRB &= ~(1<<6); PORTB &= ~(1<<6); }
 inline void ergodox_right_led_3_off(void)   { DDRB &= ~(1<<7); PORTB &= ~(1<<7); }
+inline void ergodox_right_led_off(uint8_t led) { DDRB &= ~(1<<(led+4)); PORTB &= ~(1<<(led+4)); }
 
 inline void ergodox_led_all_on(void)
 {
@@ -67,6 +69,11 @@ inline void ergodox_led_all_off(void)
 inline void ergodox_right_led_1_set(uint8_t n)    { OCR1A = n; }
 inline void ergodox_right_led_2_set(uint8_t n)    { OCR1B = n; }
 inline void ergodox_right_led_3_set(uint8_t n)    { OCR1C = n; }
+inline void ergodox_right_led_set(uint8_t led, uint8_t n)  {
+    (led == 1) ? (OCR1A = n) :
+    (led == 2) ? (OCR1B = n) :
+                 (OCR1C = n);
+}
 
 inline void ergodox_led_all_set(uint8_t n)
 {

--- a/keyboard/ergodox_ez/keymaps/keymap_dave.c
+++ b/keyboard/ergodox_ez/keymaps/keymap_dave.c
@@ -1,0 +1,183 @@
+#include "ergodox_ez.h"
+#include "debug.h"
+#include "action_layer.h"
+
+#define BASE 0 // default layer
+#define PROG 1 // symbols
+#define NAVI 2 // navigation keys
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * | Esc    |   1  |   2  |   3  |   4  |   5  |   6  |           |   6  |   7  |   8  |   9  |   0  |   -  | BkSpce |
+ * |--------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
+ * | Tab    |   Q  |   W  |   E  |   R  |   T  |   Y  |           |   G  |   Y  |   U  |   I  |   O  |   P  | Enter  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | LCtrl  |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |   ;  | Enter  |
+ * |--------+------+------+------+------+------|   H  |           |   B  |------+------+------+------+------+--------|
+ * | LShift |   Z  |   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |   /  | RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |`/Ctrl|   \  |      |      | LAlt |                                       | RAlt |      |   [  |   ]  |'/Ctrl|
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        | PrtS | Apps |       | Paus | CtAl |
+ *                                 ,------+------+------|       |------+------+------.
+ *                                 |      |      |  L1  |       |  L1  |      |      |
+ *                                 | Spce | ~L2  +------|       |------+  ~L1 | Spce |
+ *                                 |      |      | LGui |       | RGui |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+[BASE] = KEYMAP(  // layer 0 : default
+        // left hand
+        KC_ESC,   KC_1,     KC_2,    KC_3,    KC_4,    KC_5,   KC_6,
+        KC_TAB,   KC_Q,     KC_W,    KC_E,    KC_R,    KC_T,   KC_Y,
+        KC_LCTRL, KC_A,     KC_S,    KC_D,    KC_F,    KC_G,
+        KC_LSFT,  KC_Z,     KC_X,    KC_C,    KC_V,    KC_B,   KC_H,
+        CTL_T(KC_GRV),KC_NUBS,KC_NO, KC_NO,   KC_LALT,
+                                                   KC_PSCREEN,    KC_APP,
+                                                      TO(PROG, ON_PRESS),
+                                               KC_SPC, MO(NAVI), KC_LGUI,
+        // right hand
+             KC_6,    KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS, KC_BSPC,
+             KC_G,    KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,    KC_ENTER,
+                      KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN, KC_ENTER,
+             KC_B,    KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH, KC_RSFT,
+                              KC_RALT,KC_NO,  KC_LBRC,KC_RBRC, CTL_T(KC_QUOT),
+             KC_PAUS, MT(0x5, KC_NO),
+             TO(PROG, ON_PRESS),
+             KC_RGUI, MO(PROG), KC_SPC
+    ),
+
+/* Keymap 1: Symbol Layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |      |      |      |      |      |      |           |      |      |      |  K/  |  K*  |  K-  |   =    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |   !  |   @  |   (  |   )  |   |  |      |           |      |      |  K7  |  K8  |  K9  |  K+  |   #    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   #  |   $  |   {  |   }  |   `  |------|           |------|      |  K4  |  K5  |  K6  |  K+  |   '    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |      |  K1  |  K2  |  K3  |  K=  |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      |      |      |                                       |  K0  |  K0  |  K.  |  K=  |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |  L2  |       |  L2  |      |      |
+ *                                 |      |      |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+[PROG] = KEYMAP(
+       // left hand
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_EXLM, KC_AT,   KC_LCBR, KC_RCBR, KC_PIPE, KC_TRNS,
+       KC_TRNS, KC_HASH, KC_DLR,  KC_LPRN, KC_RPRN, KC_GRV,
+       KC_TRNS, KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_TILD, KC_TRNS,
+       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+                                        KC_TRNS, KC_TRNS,
+                                      TO(NAVI, ON_PRESS),
+                               KC_TRNS, KC_TRNS, KC_TRNS,
+       // right hand
+       KC_TRNS, KC_TRNS, KC_NO,  KC_PSLS, KC_PAST, KC_PMNS, KC_EQUAL,
+       KC_TRNS, KC_TRNS, KC_P7,  KC_P8,   KC_P9,   KC_PPLS, KC_NUHS,
+                KC_TRNS, KC_P4,  KC_P5,   KC_P6,   KC_PPLS, KC_QUOT,
+       KC_TRNS, KC_TRNS, KC_P1,  KC_P2,   KC_P3,   KC_PENT, KC_TRNS,
+                         KC_P0,  KC_P0,   KC_PDOT, KC_PENT, KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       TO(NAVI, ON_PRESS),
+       KC_TRNS, KC_TRNS, KC_TRNS
+),
+
+/* Keymap 2: Navigation and system keys
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |           |  F7  |  F8  |  F9  | F10  | F11  | F12  |        |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        | Home |  Up  | End  | Ins  | PgUp |      |           |      |      |      | Ins  |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        | Left | Down | Rght | Del  | PgDn |------|           |------|      | Back | Del  | Fwrd |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        | Lclk | MsUp | Rclk |      |      |      |           |      |      | Prev | Play | Next |      |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      | MsLt | MsDn | MsRt |      |                                       |VolDn | Mute |VolUp |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        | Powr |  Log |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |  L0  |       |  L0  |      |      |
+ *                                 |      |      |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+[NAVI] = KEYMAP(
+       KC_TRNS, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,
+       KC_TRNS, KC_HOME, KC_UP,   KC_END,  KC_INS,  KC_PGUP, KC_TRNS,
+       KC_TRNS, KC_LEFT, KC_DOWN, KC_RGHT, KC_DELT, KC_PGDN,
+       KC_TRNS, KC_BTN1, KC_MS_U, KC_BTN2, KC_TRNS, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_MS_L, KC_MS_D, KC_MS_R, KC_TRNS,
+                                KC_PWR, LCTL(LALT(KC_DELT)),
+                                         TO(BASE, ON_PRESS),
+                                  KC_TRNS, KC_TRNS, KC_TRNS,
+    // right hand
+       KC_F7,    KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_TRNS,
+       KC_TRNS,  KC_TRNS, KC_TRNS, KC_INS,  KC_TRNS, KC_TRNS, KC_TRNS,
+                 KC_TRNS, KC_WBAK, KC_DELT, KC_WFWD, KC_TRNS, KC_TRNS,
+       KC_TRNS,  KC_TRNS, KC_MPRV, KC_MPLY, KC_MNXT, KC_TRNS, KC_TRNS,
+                          KC_VOLD, KC_MUTE, KC_VOLU, KC_TRNS, KC_TRNS,
+       KC_TRNS, KC_TRNS,
+       TO(BASE, ON_PRESS),
+       KC_TRNS, KC_TRNS, KC_TRNS
+),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    //[1] = ACTION_LAYER_TAP_TOGGLE(PROG),               // FN1 - Momentary Layer 1 (Symbols)
+    //[2] = ACTION_LAYER_TAP_TOGGLE(NAVI)                // FN2 - Momentary Layer 2 (Navigation)
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+        if (record->event.pressed) {
+          register_code(KC_RSFT);
+        } else {
+          unregister_code(KC_RSFT);
+        }
+        break;
+      }
+    return MACRO_NONE;
+};
+
+// Runs just one time when the keyboard initializes.
+void * matrix_init_user(void) {
+    return NULL;
+};
+
+// Runs constantly in the background, in a loop.
+void * matrix_scan_user(void) {
+    static uint8_t leds[4]; // Yes, I'm wasting a byte. Sue me.
+    uint8_t led;
+    uint8_t layer = biton32(layer_state);
+
+    ergodox_board_led_off();
+
+    for (led = 1; led <= 3; ++led) {
+        leds[led] += (layer == led) ?
+            (leds[led] < 255 ? 1 : 0):
+            (leds[led] > 0 ? -1 : 0);
+        if (leds[led]) {
+            ergodox_right_led_on(led);
+            ergodox_right_led_set(led, leds[led]);
+        }
+        else {
+            ergodox_right_led_off(led);
+        }
+    }
+
+    return NULL;
+};


### PR DESCRIPTION
This moves the keys closer to a traditional layout with some redundancy around the middle to compensate for fast non-traditional typists like myself who tend to wander from the home row a fair bit. Navigation keys are provided in layer 2 (accessed by left thumb button), programming symbols and classic numeric keypad in layer 1 (accessed by right thumb button). Permanent layer switching is provided with a smaller thumb button. Ctrl provided in place of caps lock (because no-one needs
caps/num lock), space, backspace, enter, shift all in traditional positions with layer 1 providing things like equals, tilde and apostrophe (an attempt to re-use existing muscle memory).

LEDs are pimped to the point of being silly (fading in/out on layer switch, rolling on reboot ... because I can). Power and reset keys provided on left thumb pad in layer 2.

No meh or hyper as I haven't found a burning need for them (yet).

There's also some changes in the header to make playing with the LEDs a bit easier (some extra inlines, and I lowered the "LO" brightness because it was still eye-wateringly bright!), and some minor tidying of indents and squashing of compiler warnings.

To build:

```KEYMAP=dave make```

Do let me know if you want the `.hex` included too!