### PR TITLE
migrate hhkb to QMK firmware

### DIFF
--- a/keyboard/hhkb_qmk/Makefile
+++ b/keyboard/hhkb_qmk/Makefile
@@ -1,0 +1,149 @@
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device.
+#                Please customize your programmer settings(PROGRAM_CMD)
+#
+# make teensy = Download the hex file to the device, using teensy_loader_cli.
+#               (must have teensy_loader_cli installed).
+#
+# make dfu = Download the hex file to the device, using dfu-programmer (must
+#            have dfu-programmer installed).
+#
+# make flip = Download the hex file to the device, using Atmel FLIP (must
+#             have Atmel FLIP installed).
+#
+# make dfu-ee = Download the eeprom file to the device, using dfu-programmer
+#               (must have dfu-programmer installed).
+#
+# make flip-ee = Download the eeprom file to the device, using Atmel FLIP
+#                (must have Atmel FLIP installed).
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+TARGET = hhkb_qmk
+
+
+# Directory common source filess exist
+TOP_DIR = ../..
+TMK_DIR = ../../tmk_core
+
+# Directory keyboard dependent files exist
+TARGET_DIR = .
+
+# # project specific files
+SRC = hhkb_qmk.c \
+      matrix.c
+
+ifdef KEYMAP
+    SRC := keymaps/keymap_$(KEYMAP).c $(SRC)
+else
+    SRC := keymaps/keymap_default.c $(SRC)
+endif
+
+CONFIG_H = config.h
+
+# MCU name
+#MCU = at90usb1287
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Boot Section Size in *bytes*
+#   Teensy halfKay   512
+#   Teensy++ halfKay 1024
+#   Atmel DFU loader 4096
+#   LUFA bootloader  4096
+#   USBaspLoader     2048
+#OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+# as per original hasu settings
+OPT_DEFS += -DBOOTLOADER_SIZE=512
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = yes	# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes	# Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
+CONSOLE_ENABLE = yes	# Console for debug(+400)
+COMMAND_ENABLE = yes    # Commands for debug and configuration
+CUSTOM_MATRIX    = yes # Custom matrix file for the HHKB
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+# SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
+# NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+# BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
+# MIDI_ENABLE = YES		# MIDI controls
+# UNICODE_ENABLE = YES		# Unicode
+# BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
+
+
+# Optimize size but this may cause error "relocation truncated to fit"
+#EXTRALDFLAGS = -Wl,--relax
+
+# Search Path
+VPATH += $(TARGET_DIR)
+VPATH += $(TOP_DIR)
+VPATH += $(TMK_DIR)
+
+debug-on: EXTRAFLAGS += -DDEBUG -DDEBUG_ACTION
+debug-on: all
+
+debug-off: EXTRAFLAGS += -DNO_DEBUG -DNO_PRINT
+debug-off: OPT_DEFS := $(filter-out -DCONSOLE_ENABLE,$(OPT_DEFS))
+debug-off: all
+
+include $(TOP_DIR)/quantum/quantum.mk

--- a/keyboard/hhkb_qmk/README.md
+++ b/keyboard/hhkb_qmk/README.md
@@ -1,0 +1,180 @@
+hhkb_qmk keyboard firmware
+======================
+
+## Quantum MK Firmware
+
+You have access to a bunch of goodies! Check out the Makefile to enable/disable some of the features. Uncomment the `#` to enable them. Setting them to `no` does nothing and will only confuse future you.
+
+    BACKLIGHT_ENABLE = yes # Enable keyboard backlight functionality
+    MIDI_ENABLE = yes      # MIDI controls
+    # UNICODE_ENABLE = yes # Unicode support - this is commented out, just as an example. You have to use #, not //
+    BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
+
+## Quick aliases to common actions
+
+Your keymap can include shortcuts to common operations (called "function actions" in tmk).
+
+### Switching and toggling layers
+
+`MO(layer)` - momentary switch to *layer*. As soon as you let go of the key, the layer is deactivated and you pop back out to the previous layer. When you apply this to a key, that same key must be set as `KC_TRNS` on the destination layer. Otherwise, you won't make it back to the original layer when you release the key (and you'll get a keycode sent). You can only switch to layers *above* your current layer. If you're on layer 0 and you use `MO(1)`, that will switch to layer 1 just fine. But if you include `MO(3)` on layer 5, that won't do anything for you -- because layer 3 is lower than layer 5 on the stack.
+
+`LT(layer, kc)` - momentary switch to *layer* when held, and *kc* when tapped. Like `MO()`, this only works upwards in the layer stack (`layer` must be higher than the current layer).
+
+`TG(layer)` - toggles a layer on or off. As with `MO()`, you should set this key as `KC_TRNS` in the destination layer so that tapping it again actually toggles back to the original layer. Only works upwards in the layer stack.
+
+### Fun with modifier keys
+
+* `LSFT(kc)` - applies left Shift to *kc* (keycode) - `S(kc)` is an alias
+* `RSFT(kc)` - applies right Shift to *kc*
+* `LCTL(kc)` - applies left Control to *kc*
+* `RCTL(kc)` - applies right Control to *kc*
+* `LALT(kc)` - applies left Alt to *kc*
+* `RALT(kc)` - applies right Alt to *kc*
+* `LGUI(kc)` - applies left GUI (command/win) to *kc*
+* `RGUI(kc)` - applies right GUI (command/win) to *kc*
+
+You can also chain these, like this:
+
+    LALT(LCTL(KC_DEL)) -- this makes a key that sends Alt, Control, and Delete in a single keypress.
+
+The following shortcuts automatically add `LSFT()` to keycodes to get commonly used symbols. Their long names are also available and documented in `/quantum/keymap_common.h`.
+
+    KC_TILD  ~
+    KC_EXLM  !
+    KC_AT    @
+    KC_HASH  #
+    KC_DLR   $
+    KC_PERC  %
+    KC_CIRC  ^
+    KC_AMPR  &
+    KC_ASTR  *
+    KC_LPRN  (
+    KC_RPRN  )
+    KC_UNDS  _
+    KC_PLUS  +
+    KC_LCBR  {
+    KC_RCBR  }
+    KC_PIPE  |
+    KC_COLN  :
+
+`MT(mod, kc)` - is *mod* (modifier key - MOD_LCTL, MOD_LSFT) when held, and *kc* when tapped. In other words, you can have a key that sends Esc (or the letter O or whatever) when you tap it, but works as a Control key or a Shift key when you hold it down. 
+
+These are the values you can use for the `mod` in `MT()` (right-hand modifiers are not available):
+
+  * MOD_LCTL
+  * MOD_LSFT
+  * MOD_LALT
+  * MOD_LGUI
+
+These can also be combined like `MOD_LCTL | MOD_LSFT` e.g. `MT(MOD_LCTL | MOD_LSFT, KC_ESC)` which would activate Control and Shift when held, and send Escape when tapped.
+
+We've added shortcuts to make common modifier/tap (mod-tap) mappings more compact:
+
+  * `CTL_T(kc)` - is LCTL when held and *kc* when tapped 
+  * `SFT_T(kc)` - is LSFT when held and *kc* when tapped 
+  * `ALT_T(kc)` - is LALT when held and *kc* when tapped 
+  * `GUI_T(kc)` - is LGUI when held and *kc* when tapped 
+  * `ALL_T(kc)` - is Hyper (all mods) when held and *kc* when tapped. To read more about what you can do with a Hyper key, see [this blog post by Brett Terpstra](http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/)
+
+### Temporarily setting the default layer 
+
+`DF(layer)` - sets default layer to *layer*. The default layer is the one at the "bottom" of the layer stack - the ultimate fallback layer. This currently does not persist over power loss. When you plug the keyboard back in, layer 0 will always be the default. It is theoretically possible to work around that, but that's not what `DF` does.
+
+### Remember: These are just aliases
+
+These functions work the same way that their `ACTION_*` functions do - they're just quick aliases. To dig into all of the tmk ACTION_* functions, please see the [TMK documentation](https://github.com/jackhumbert/qmk_firmware/blob/master/tmk_core/doc/keymap.md#2-action).
+
+Instead of using `FNx` when defining `ACTION_*` functions, you can use `F(x)` - the benefit here is being able to use more than 32 function actions (up to 4096), if you happen to need them.
+
+## Macro shortcuts: Send a whole string when pressing just one key
+
+Instead of using the `ACTION_MACRO` function, you can simply use `M(n)` to access macro *n* - *n* will get passed into the `action_get_macro` as the `id`, and you can use a switch statement to trigger it. This gets called on the keydown and keyup, so you'll need to use an if statement testing `record->event.pressed` (see keymap_default.c).
+
+```c
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt) // this is the function signature -- just copy/paste it into your keymap file as it is.
+{
+  switch(id) {
+    case 0: // this would trigger when you hit a key mapped as M(0)
+      if (record->event.pressed) {
+        return MACRO( I(255), T(H), T(E), T(L), T(L), W(255), T(O), END  ); // this sends the string 'hello' when the macro executes
+      } 
+      break;
+  }
+  return MACRO_NONE;
+};
+```
+A macro can include the following commands:
+
+* I() change interval of stroke in milliseconds.
+* D() press key.
+* U() release key.
+* T() type key(press and release).
+* W() wait (milliseconds).
+* END end mark.
+
+So above you can see the stroke interval changed to 255ms between each keystroke, then a bunch of keys being typed, waits a while, then the macro ends.
+
+Note: Using macros to have your keyboard send passwords for you is a bad idea.
+
+### Additional keycode aliases for software-implemented layouts (Colemak, Dvorak, etc)
+
+Everything is assuming you're in Qwerty (in software) by default, but there is built-in support for using a Colemak or Dvorak layout by including this at the top of your keymap:
+
+   #include "keymap_<layout>.h"
+
+Where <layout> is "colemak" or "dvorak". After including this line, you will get access to:
+ 
+ * `CM_*` for all of the Colemak-equivalent characters
+ * `DV_*` for all of the Dvorak-equivalent characters
+ 
+These implementations assume you're using Colemak or Dvorak on your OS, not on your keyboard - this is referred to as a software-implemented layout. If your computer is in Qwerty and your keymap is in Colemak or Dvorak, this is referred to as a firmware-implemented layout, and you won't need these features. 
+
+To give an example, if you're using software-implemented Colemak, and want to get an `F`, you would use `CM_F` - `KC_F` under these same circumstances would result in `T`.
+
+## Additional language support
+
+In `quantum/keymap_extras/`, you'll see various language files - these work the same way as the alternative layout ones do. Most are defined by their two letter country/language code followed by an underscore and a 4-letter abbreviation of its name. `FR_UGRV` which will result in a `ù` when using a software-implemented AZERTY layout. It's currently difficult to send such characters in just the firmware (but it's being worked on - see Unicode support).
+
+## Unicode support
+
+You can currently send 4 hex digits with your OS-specific modifier key (RALT for OSX with the "Unicode Hex Input" layout) - this is currently limited to supporting one OS at a time, and requires a recompile for switching. 8 digit hex codes are being worked on. The keycode function is `UC(n)`, where *n* is a 4 digit hexidecimal. Enable from the Makefile.
+
+## Other firmware shortcut keycodes
+
+* `RESET` - puts the MCU in DFU mode for flashing new firmware (with `make dfu`)
+* `DEBUG` - the firmware into debug mode - you'll need hid_listen to see things
+* `BL_ON` - turns the backlight on
+* `BL_OFF` - turns the backlight off
+* `BL_<n>` - sets the backlight to level *n*
+* `BL_INC` - increments the backlight level by one
+* `BL_DEC` - decrements the backlight level by one
+* `BL_TOGG` - toggles the backlight
+* `BL_STEP` - steps through the backlight levels
+
+Enable the backlight from the Makefile.
+
+## MIDI functionalty
+
+This is still a WIP, but check out `quantum/keymap_midi.c` to see what's happening. Enable from the Makefile.
+
+## Bluetooth functionality
+
+This requires [some hardware changes](https://www.reddit.com/r/MechanicalKeyboards/comments/3psx0q/the_planck_keyboard_with_bluetooth_guide_and/?ref=search_posts), but can be enabled via the Makefile. The firmware will still output characters via USB, so be aware of this when charging via a computer. It would make sense to have a switch on the Bluefruit to turn it off at will.
+
+## Building
+
+Download or clone the whole firmware and navigate to the keyboard/planck folder. Once your dev env is setup, you'll be able to type `make` to generate your .hex - you can then use `make dfu` to program your PCB once you hit the reset button. 
+
+Depending on which keymap you would like to use, you will have to compile slightly differently.
+
+### Default
+To build with the default keymap, simply run `make`.
+
+### Other Keymaps
+Several version of keymap are available in advance but you are recommended to define your favorite layout yourself. To define your own keymap create file named `keymap_<name>.c` and see keymap document (you can find in top README.md) and existent keymap files.
+
+To build the firmware binary hex file with a keymap just do `make` with `KEYMAP` option like:
+```
+$ make KEYMAP=[default|jack|<name>]
+```
+Keymaps follow the format **__keymap\_\<name\>.c__** and are stored in the `keymaps` folder.

--- a/keyboard/hhkb_qmk/config.h
+++ b/keyboard/hhkb_qmk/config.h
@@ -1,0 +1,71 @@
+/*
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0xCAFE
+#define DEVICE_VER      0x0104
+#define MANUFACTURER    q.m.k
+#define PRODUCT         HHKB mod
+#define DESCRIPTION     q.m.k keyboard firmware for HHKB
+
+/* key matrix size */
+#define MATRIX_ROWS 8
+#define MATRIX_COLS 8
+
+#define TAPPING_TERM    200
+
+/* number of backlight levels */
+#define BACKLIGHT_LEVELS 3
+
+/* Set 0 if debouncing isn't needed */
+#define DEBOUNCE    5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+//#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+//#define LOCKING_RESYNC_ENABLE
+
+/* key combination for command */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+)
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+*/
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
+
+#endif

--- a/keyboard/hhkb_qmk/hhkb_avr.h
+++ b/keyboard/hhkb_qmk/hhkb_avr.h
@@ -1,0 +1,167 @@
+#ifndef HHKB_AVR_H
+#define HHKB_AVR_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <util/delay.h>
+
+
+// Timer resolution check
+#if (1000000/TIMER_RAW_FREQ > 20)
+#   error "Timer resolution(>20us) is not enough for HHKB matrix scan tweak on V-USB."
+#endif
+
+
+/*
+ * HHKB Matrix I/O
+ *
+ * row:     HC4051[A,B,C]  selects scan row0-7
+ * row-ext: [En0,En1] row extention for JP
+ * col:     LS145[A,B,C,D] selects scan col0-7 and enable(D)
+ * key:     on: 0/off: 1
+ * prev:    hysteresis control: assert(1) when previous key state is on
+ */
+
+
+#if defined(__AVR_ATmega32U4__)
+/*
+ * For TMK HHKB alt controller(ATMega32U4)
+ *
+ * row:     PB0-2
+ * col:     PB3-5,6
+ * key:     PD7(pull-uped)
+ * prev:    PB7
+ * power:   PD4(L:off/H:on)
+ * row-ext: PC6,7 for HHKB JP(active low)
+ */
+static inline void KEY_ENABLE(void) { (PORTB &= ~(1<<6)); }
+static inline void KEY_UNABLE(void) { (PORTB |=  (1<<6)); }
+static inline bool KEY_STATE(void) { return (PIND & (1<<7)); }
+static inline void KEY_PREV_ON(void) { (PORTB |=  (1<<7)); }
+static inline void KEY_PREV_OFF(void) { (PORTB &= ~(1<<7)); }
+#ifdef HHKB_POWER_SAVING
+static inline void KEY_POWER_ON(void) {
+    DDRB = 0xFF; PORTB = 0x40;          // change pins output
+    DDRD |= (1<<4); PORTD |= (1<<4);    // MOS FET switch on
+    /* Without this wait you will miss or get false key events. */
+    _delay_ms(5);                       // wait for powering up
+}
+static inline void KEY_POWER_OFF(void) {
+    /* input with pull-up consumes less than without it when pin is open. */
+    DDRB = 0x00; PORTB = 0xFF;          // change pins input with pull-up
+    DDRD |= (1<<4); PORTD &= ~(1<<4);   // MOS FET switch off
+}
+static inline bool KEY_POWER_STATE(void) { return PORTD & (1<<4); }
+#else
+static inline void KEY_POWER_ON(void) {}
+static inline void KEY_POWER_OFF(void) {}
+static inline bool KEY_POWER_STATE(void) { return true; }
+#endif
+static inline void KEY_INIT(void)
+{
+    /* row,col,prev: output */
+    DDRB  = 0xFF;
+    PORTB = 0x40;   // unable
+    /* key: input with pull-up */
+    DDRD  &= ~0x80;
+    PORTD |=  0x80;
+#ifdef HHKB_JP
+    /* row extention for HHKB JP */
+    DDRC  |= (1<<6|1<<7);
+    PORTC |= (1<<6|1<<7);
+#endif
+    KEY_UNABLE();
+    KEY_PREV_OFF();
+
+    KEY_POWER_OFF();
+}
+static inline void KEY_SELECT(uint8_t ROW, uint8_t COL)
+{
+    PORTB = (PORTB & 0xC0) | (((COL) & 0x07)<<3) | ((ROW) & 0x07);
+#ifdef HHKB_JP
+    if ((ROW) & 0x08) PORTC = (PORTC & ~(1<<6|1<<7)) | (1<<6);
+    else              PORTC = (PORTC & ~(1<<6|1<<7)) | (1<<7);
+#endif
+}
+
+
+#elif defined(__AVR_AT90USB1286__)
+/*
+ * For Teensy++(AT90USB1286)
+ *
+ *                          HHKB pro    HHKB pro2
+ * row:     PB0-2           (6-8)       (5-7)
+ * col:     PB3-5,6         (9-12)      (8-11)
+ * key:     PE6(pull-uped)  (4)         (3)
+ * prev:    PE7             (5)         (4)
+ *
+ * TODO: convert into 'staitc inline' function
+ */
+#define KEY_INIT()              do {    \
+    DDRB |= 0x7F;                       \
+    DDRE |=  (1<<7);                    \
+    DDRE &= ~(1<<6);                    \
+    PORTE |= (1<<6);                    \
+} while (0)
+#define KEY_SELECT(ROW, COL)    (PORTB = (PORTB & 0xC0) |       \
+                                         (((COL) & 0x07)<<3) |  \
+                                         ((ROW) & 0x07))
+#define KEY_ENABLE()            (PORTB &= ~(1<<6))
+#define KEY_UNABLE()            (PORTB |=  (1<<6))
+#define KEY_STATE()             (PINE & (1<<6))
+#define KEY_PREV_ON()           (PORTE |=  (1<<7))
+#define KEY_PREV_OFF()          (PORTE &= ~(1<<7))
+#define KEY_POWER_ON()
+#define KEY_POWER_OFF()
+#define KEY_POWER_STATE()       true
+
+
+#else
+#   error "define code for matrix scan"
+#endif
+
+
+#if 0
+// For ATMega328P with V-USB
+//
+// #elif defined(__AVR_ATmega328P__)
+// Ports for V-USB
+// key:     PB0(pull-uped)
+// prev:    PB1
+// row:     PB2-4
+// col:     PC0-2,3
+// power:   PB5(Low:on/Hi-z:off)
+#define KEY_INIT()              do {    \
+    DDRB  |= 0x3E;                      \
+    DDRB  &= ~(1<<0);                   \
+    PORTB |= 1<<0;                      \
+    DDRC  |= 0x0F;                      \
+    KEY_UNABLE();                       \
+    KEY_PREV_OFF();                     \
+} while (0)
+#define KEY_SELECT(ROW, COL)    do {    \
+    PORTB = (PORTB & 0xE3) | ((ROW) & 0x07)<<2; \
+    PORTC = (PORTC & 0xF8) | ((COL) & 0x07);    \
+} while (0)
+#define KEY_ENABLE()            (PORTC &= ~(1<<3))
+#define KEY_UNABLE()            (PORTC |=  (1<<3))
+#define KEY_STATE()             (PINB & (1<<0))
+#define KEY_PREV_ON()           (PORTB |=  (1<<1))
+#define KEY_PREV_OFF()          (PORTB &= ~(1<<1))
+// Power supply switching
+#define KEY_POWER_ON()          do {    \
+    KEY_INIT();                         \
+    PORTB &= ~(1<<5);                   \
+    _delay_ms(1);                       \
+} while (0)
+#define KEY_POWER_OFF()         do {    \
+    DDRB  &= ~0x3F;                     \
+    PORTB &= ~0x3F;                     \
+    DDRC  &= ~0x0F;                     \
+    PORTC &= ~0x0F;                     \
+} while (0)
+#endif
+
+#endif

--- a/keyboard/hhkb_qmk/hhkb_qmk.c
+++ b/keyboard/hhkb_qmk/hhkb_qmk.c
@@ -1,0 +1,29 @@
+#include "hhkb_qmk.h"
+
+__attribute__ ((weak))
+void * matrix_init_user(void) {
+	// leave these blank
+};
+
+__attribute__ ((weak))
+void * matrix_scan_user(void) {
+	// leave these blank
+};
+
+void * matrix_init_kb(void) {
+	// put your keyboard start-up code here
+	// runs once when the firmware starts up
+
+	if (matrix_init_user) {
+		(*matrix_init_user)();
+	}
+};
+
+void * matrix_scan_kb(void) {
+	// put your looping keyboard code here
+	// runs every cycle (a lot)
+
+	if (matrix_scan_user) {
+		(*matrix_scan_user)();
+	}
+};

--- a/keyboard/hhkb_qmk/hhkb_qmk.h
+++ b/keyboard/hhkb_qmk/hhkb_qmk.h
@@ -1,0 +1,30 @@
+#ifndef HHKB_QMK_H
+#define HHKB_QMK_H
+
+#include "matrix.h"
+#include "keymap_common.h"
+//#include "backlight.h"
+#include <stddef.h>
+
+#define KEYMAP(                                                                \
+    K31, K30, K00, K10, K11, K20, K21, K40, K41, K60, K61, K70, K71, K50, K51, \
+    K32, K01, K02, K13, K12, K23, K22, K42, K43, K62, K63, K73, K72, K52,      \
+    K33, K04, K03, K14, K15, K24, K25, K45, K44, K65, K64, K74, K53,           \
+    K34, K05, K06, K07, K16, K17, K26, K46, K66, K76, K75, K55, K54,           \
+         K35, K36,           K37,                K57, K56)                     \
+                                                                               \
+{                                                                              \
+    { K00, K01, K02, K03, K04, K05, K06, K07   },                              \
+    { K10, K11, K12, K13, K14, K15, K16, K17   },                              \
+    { K20, K21, K22, K23, K24, K25, K26, KC_NO },                              \
+    { K30, K31, K32, K33, K34, K35, K36, K37   },                              \
+    { K40, K41, K42, K43, K44, K45, K46, KC_NO },                              \
+    { K50, K51, K52, K53, K54, K55, K56, K57   },                              \
+    { K60, K61, K62, K63, K64, K65, K66, KC_NO },                              \
+    { K70, K71, K72, K73, K74, K75, K76, KC_NO }                               \
+}
+
+void * matrix_init_user(void);
+void * matrix_scan_user(void);
+
+#endif

--- a/keyboard/hhkb_qmk/keymaps/keymap_default.c
+++ b/keyboard/hhkb_qmk/keymaps/keymap_default.c
@@ -1,0 +1,78 @@
+/*  -*-  eval: (turn-on-orgtbl); -*-
+ * default HHKB Layout
+ */
+#include "hhkb_qmk.h"
+
+#define BASE 0
+#define HHKB 1
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    /* BASE Level: Default Layer
+     |-------+---+---+---+---+---+---+---+---+---+---+-------+-----+-------+---|
+     | Esc   | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | -     | =   | \     | ` |
+     |-------+---+---+---+---+---+---+---+---+---+---+-------+-----+-------+---|
+     | Tab   | Q | W | E | R | T | Y | U | I | O | P | [     | ]   | Backs |   |
+     |-------+---+---+---+---+---+---+---+---+---+---+-------+-----+-------+---|
+     | Cont  | A | S | D | F | G | H | J | K | L | ; | '     | Ent |       |   |
+     |-------+---+---+---+---+---+---+---+---+---+---+-------+-----+-------+---|
+     | Shift | Z | X | C | V | B | N | M | , | . | / | Shift | Fn0 |       |   |
+     |-------+---+---+---+---+---+---+---+---+---+---+-------+-----+-------+---|
+
+            |------+------+-----------------------+------+------|
+            | LAlt | LGUI | ******* Space ******* | RGUI | RAlt |
+            |------+------+-----------------------+------+------|
+    */
+
+  [BASE] = KEYMAP(  //  default layer
+  KC_ESC,   KC_1,  KC_2,  KC_3,  KC_4,  KC_5,  KC_6,  KC_7,  KC_8,     KC_9,    KC_0,     KC_MINS,  KC_EQL,    KC_BSLS,  KC_GRV, \
+  KC_TAB,   KC_Q,  KC_W,  KC_E,  KC_R,  KC_T,  KC_Y,  KC_U,  KC_I,     KC_O,    KC_P,     KC_LBRC,  KC_RBRC,   KC_BSPC,          \
+  KC_LCTL,  KC_A,  KC_S,  KC_D,  KC_F,  KC_G,  KC_H,  KC_J,  KC_K,     KC_L,    KC_SCLN,  KC_QUOT,  KC_ENT,                      \
+  KC_LSFT,  KC_Z,  KC_X,  KC_C,  KC_V,  KC_B,  KC_N,  KC_M,  KC_COMM,  KC_DOT,  KC_SLSH,  KC_RSFT,  MO(HHKB),                    \
+                    KC_LALT,  KC_LGUI,  /*        */ KC_SPC,      KC_RGUI,  KC_RALT),
+
+
+
+    /* Layer HHKB: HHKB mode (HHKB Fn)
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+      | Pwr  | F1  | F2  | F3  | F4 | F5 | F6 | F7 | F8  | F9  | F10 | F11 | F12   | Ins   | Del |
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+      | Caps |     |     |     |    |    |    |    | Psc | Slk | Pus | Up  |       | Backs |     |
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+      |      | VoD | VoU | Mut |    |    | *  | /  | Hom | PgU | Lef | Rig | Enter |       |     |
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+      |      |     |     |     |    |    | +  | -  | End | PgD | Dow |     |       |       |     |
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+
+                 |------+------+----------------------+------+------+
+                 | **** | **** | ******************** | **** | **** |
+                 |------+------+----------------------+------+------+
+
+     */
+
+  [HHKB] = KEYMAP(
+  KC_PWR,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL, \
+  KC_CAPS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_UP,    KC_TRNS,  KC_BSPC,          \
+  KC_TRNS,  KC_VOLD,  KC_VOLU,  KC_MUTE,  KC_TRNS,  KC_TRNS,  KC_PAST,  KC_PSLS,  KC_HOME,  KC_PGUP,  KC_LEFT,  KC_RGHT,  KC_PENT,                    \
+  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_PPLS,  KC_PMNS,  KC_END,   KC_PGDN,  KC_DOWN,  KC_TRNS,  KC_TRNS,                    \
+                     KC_TRNS, KC_TRNS,           KC_TRNS,                KC_TRNS, KC_TRNS)};
+
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+          } else {
+            unregister_code(KC_RSFT);
+          }
+        break;
+      }
+    return MACRO_NONE;
+};

--- a/keyboard/hhkb_qmk/keymaps/keymap_lxol.c
+++ b/keyboard/hhkb_qmk/keymaps/keymap_lxol.c
@@ -1,0 +1,208 @@
+/*  -*-  eval: (turn-on-orgtbl); -*-
+ * lxol HHKB Layout
+ */
+#include "hhkb_qmk.h"
+
+#define BASE 0
+#define WIN 1
+#define HHKB 2
+#define RGUILEV 3
+#define LGUILEV 4
+#define RALTLEV 5
+#define LALTLEV 6
+
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    /* Layer 0: Default Layer
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Esc    | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0   | -     | =        | \     | ` |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Tab    | Q | W | E | R | T | Y | U | I | O | P   | [     | ]        | Backs |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Contro | A | S | D | F | G | H | J | K | L | ;   | '     | RCtl/Ent |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Shift  | Z | X | C | V | B | N | M | , | . | Fn2 | Shift | Fn0      |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+
+                 |------+------+-------+------+------|
+                 | LAlt | LGUI | Space | RGUI | RAlt |
+                 |------+------+-------+------+------|
+    */
+
+  [BASE] = KEYMAP(  // layer 0 : default
+
+
+  KC_ESC,   KC_1,              KC_2,              KC_3,  KC_4,  KC_5,  KC_6,  KC_7,  KC_8,     KC_9,              KC_0,                 KC_MINS,  KC_EQL,    KC_BSLS,  KC_GRV,  \
+  KC_TAB,   KC_Q,              KC_W,              KC_E,  KC_R,  KC_T,  KC_Y,  KC_U,  KC_I,     KC_O,              KC_P,                 KC_LBRC,  KC_RBRC,   KC_BSPC,  \
+  KC_LCTL,  LT(LALTLEV,KC_A),  LT(LGUILEV,KC_S),  KC_D,  KC_F,  KC_G,  KC_H,  KC_J,  KC_K,     LT(RGUILEV,KC_L),  LT(RALTLEV,KC_SCLN),  KC_QUOT,  KC_FN0,    \
+  KC_LSFT,  KC_Z,              KC_X,              KC_C,  KC_V,  KC_B,  KC_N,  KC_M,  KC_COMM,  KC_DOT,            KC_SLSH,              KC_RSFT,  MO(HHKB),  \
+      KC_LALT, KC_LGUI, KC_SPC,                KC_RGUI, KC_RALT),
+
+
+
+    /* Layer 1: HHKB mode (HHKB Fn)
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+      | Pwr  | F1  | F2  | F3  | F4 | F5 | F6 | F7 | F8  | F9  | F10 | F11 | F12   | Ins   | Del |
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+      | Caps |     |     |     |    |    |    |    | Psc | Slk | Pus | Up  |       | Backs |     |
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+      |      | VoD | VoU | Mut |    |    | *  | /  | Hom | PgU | Lef | Rig | Enter |       |     |
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+      |      |     |     |     |    |    | +  | -  | End | PgD | Dow |     |       |       |     |
+      |------+-----+-----+-----+----+----+----+----+-----+-----+-----+-----+-------+-------+-----|
+
+                      |---+---+---+---+---|
+                      |   |   |   |   |   |
+                      |---+---+---+---+---|
+     */
+
+  [HHKB] = KEYMAP(
+  KC_PWR,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_INS,   KC_DEL, \
+  KC_CAPS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_PSCR,  KC_SLCK,  KC_PAUS,  KC_UP,    KC_TRNS,  KC_BSPC,          \
+  KC_TRNS,  KC_VOLD,  KC_VOLU,  KC_MUTE,  KC_TRNS,  KC_TRNS,  KC_PAST,  KC_PSLS,  KC_HOME,  KC_PGUP,  KC_LEFT,  KC_RGHT,  KC_PENT,                    \
+  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_PPLS,  KC_PMNS,  KC_END,   KC_PGDN,  KC_DOWN,  KC_TRNS,  KC_TRNS,                    \
+  KC_TRNS, KC_TRNS,           KC_TRNS,                KC_TRNS, KC_TRNS),
+
+
+    /* Layer LGUI: All keys with RGUI modifier
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Esc    | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0   | -     | =        | \     | ` |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Tab    | Q | W | E | R | T | Y | U | I | O | P   | [     | ]        | Backs |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Contro | A | S | D | F | G | H | J | K |   | ;   | '     | RCtl/Ent |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Shift  | Z | X | C | V | B | N | M | , | . | Fn2 | Shift | Fn0      |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+
+                 |------+------+-------+------+------|
+                 | LAlt | LGUI | Space | RGUI | RAlt |
+                 |------+------+-------+------+------|
+    */
+
+  [RGUILEV] = KEYMAP(  // Right GUI layer  by KC_L
+
+  RGUI(KC_ESC),   RGUI(KC_1),  RGUI(KC_2),  RGUI(KC_3),  RGUI(KC_4),  RGUI(KC_5),  RGUI(KC_6),  RGUI(KC_7),  RGUI(KC_8),     RGUI(KC_9),    RGUI(KC_0),     RGUI(KC_MINS),  RGUI(KC_EQL),   RGUI(KC_BSLS),  RGUI(KC_GRV),  \
+  RGUI(KC_TAB),   RGUI(KC_Q),  RGUI(KC_W),  RGUI(KC_E),  RGUI(KC_R),  RGUI(KC_T),  RGUI(KC_Y),  RGUI(KC_U),  RGUI(KC_I),     RGUI(KC_O),    RGUI(KC_P),     RGUI(KC_LBRC),  RGUI(KC_RBRC),  RGUI(KC_BSPC),  \
+  RGUI(KC_LCTL),  RGUI(KC_A),  RGUI(KC_S),  RGUI(KC_D),  RGUI(KC_F),  RGUI(KC_G),  RGUI(KC_H),  RGUI(KC_J),  RGUI(KC_K),     KC_TRNS,       KC_TRNS,        RGUI(KC_QUOT),  KC_FN0,         \
+  RGUI(KC_LSFT),  RGUI(KC_Z),  RGUI(KC_X),  RGUI(KC_C),  RGUI(KC_V),  RGUI(KC_B),  RGUI(KC_N),  RGUI(KC_M),  RGUI(KC_COMM),  RGUI(KC_DOT),  RGUI(KC_SLSH),  RGUI(KC_RSFT),  KC_TRNS,        \
+      KC_LALT, KC_LGUI, RGUI(KC_SPC),               KC_RGUI, KC_RALT),
+
+    /* Layer LGUI: All keys with LGUI modifier
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Esc    | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0   | -     | =        | \     | ` |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Tab    | Q | W | E | R | T | Y | U | I | O | P   | [     | ]        | Backs |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Contro | A | S | D | F | G | H | J | K |   | ;   | '     | RCtl/Ent |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Shift  | Z | X | C | V | B | N | M | , | . | Fn2 | Shift | Fn0      |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+
+                 |------+------+-------+------+------|
+                 | LAlt | LGUI | Space | LGUI | RAlt |
+                 |------+------+-------+------+------|
+    */
+
+  [LGUILEV] = KEYMAP(  // Right GUI layer  by KC_L
+
+  LGUI(KC_ESC),   LGUI(KC_1),  LGUI(KC_2),  LGUI(KC_3),  LGUI(KC_4),  LGUI(KC_5),  LGUI(KC_6),  LGUI(KC_7),  LGUI(KC_8),     LGUI(KC_9),    LGUI(KC_0),     LGUI(KC_MINS),  LGUI(KC_EQL),   LGUI(KC_BSLS),  LGUI(KC_GRV),  \
+  LGUI(KC_TAB),   LGUI(KC_Q),  LGUI(KC_W),  LGUI(KC_E),  LGUI(KC_R),  LGUI(KC_T),  LGUI(KC_Y),  LGUI(KC_U),  LGUI(KC_I),     LGUI(KC_O),    LGUI(KC_P),     LGUI(KC_LBRC),  LGUI(KC_RBRC),  LGUI(KC_BSPC),  \
+  LGUI(KC_LCTL),  KC_TRNS,     KC_TRNS,     LGUI(KC_D),  LGUI(KC_F),  LGUI(KC_G),  LGUI(KC_H),  LGUI(KC_J),  LGUI(KC_K),     LGUI(KC_L),    LGUI(KC_SCLN),  LGUI(KC_QUOT),  KC_FN0,         \
+  KC_LSFT,        LGUI(KC_Z),  LGUI(KC_X),  LGUI(KC_C),  LGUI(KC_V),  LGUI(KC_B),  LGUI(KC_N),  LGUI(KC_M),  LGUI(KC_COMM),  LGUI(KC_DOT),  LGUI(KC_SLSH),  KC_RSFT,        KC_TRNS,        \
+      KC_LALT, KC_LGUI, LGUI(KC_SPC),               KC_LGUI, KC_RALT),
+
+    /* Layer LALT: All keys with RALT modifier
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Esc    | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0   | -     | =        | \     | ` |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Tab    | Q | W | E | R | T | Y | U | I | O | P   | [     | ]        | Backs |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Contro | A | S | D | F | G | H | J | K |   | ;   | '     | RCtl/Ent |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Shift  | Z | X | C | V | B | N | M | , | . | Fn2 | Shift | Fn0      |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+
+                 |------+------+-------+------+------|
+                 | LAlt | LGUI | Space | RGUI | RAlt |
+                 |------+------+-------+------+------|
+    */
+
+  [RALTLEV] = KEYMAP(  // Right ALT layer  by KC_L
+
+  RALT(KC_ESC),   RALT(KC_1),  RALT(KC_2),  RALT(KC_3),  RALT(KC_4),  RALT(KC_5),  RALT(KC_6),  RALT(KC_7),  RALT(KC_8),     RALT(KC_9),    RALT(KC_0),     RALT(KC_MINS),  RALT(KC_EQL),   RALT(KC_BSLS),  RALT(KC_GRV),  \
+  RALT(KC_TAB),   RALT(KC_Q),  RALT(KC_W),  RALT(KC_E),  RALT(KC_R),  RALT(KC_T),  RALT(KC_Y),  RALT(KC_U),  RALT(KC_I),     RALT(KC_O),    RALT(KC_P),     RALT(KC_LBRC),  RALT(KC_RBRC),  RALT(KC_BSPC),  \
+  RALT(KC_LCTL),  RALT(KC_A),  RALT(KC_S),  RALT(KC_D),  RALT(KC_F),  RALT(KC_G),  RALT(KC_H),  RALT(KC_J),  RALT(KC_K),     KC_TRNS,       KC_TRNS,        RALT(KC_QUOT),  KC_FN0,         \
+  RALT(KC_LSFT),  RALT(KC_Z),  RALT(KC_X),  RALT(KC_C),  RALT(KC_V),  RALT(KC_B),  RALT(KC_N),  RALT(KC_M),  RALT(KC_COMM),  RALT(KC_DOT),  RALT(KC_SLSH),  RALT(KC_RSFT),  KC_TRNS,        \
+      KC_LALT, KC_LGUI, RALT(KC_SPC),               KC_RGUI, KC_RALT),
+
+    /* Layer LALT: All keys with LALT modifier
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Esc    | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0   | -     | =        | \     | ` |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Tab    | Q | W | E | R | T | Y | U | I | O | P   | [     | ]        | Backs |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Contro | A | S | D | F | G | H | J | K |   | ;   | '     | RCtl/Ent |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+     | Shift  | Z | X | C | V | B | N | M | , | . | Fn2 | Shift | Fn0      |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+-----+-------+----------+-------+---|
+
+                 |------+------+-------+------+------|
+                 | LAlt | LGUI | Space | LGUI | RAlt |
+                 |------+------+-------+------+------|
+    */
+
+  [LALTLEV] = KEYMAP(  // Right ALT layer  by KC_L
+
+  LALT(KC_ESC),   LALT(KC_1),  LALT(KC_2),  LALT(KC_3),  LALT(KC_4),  LALT(KC_5),  LALT(KC_6),  LALT(KC_7),  LALT(KC_8),     LALT(KC_9),    LALT(KC_0),     LALT(KC_MINS),  LALT(KC_EQL),   LALT(KC_BSLS),  LALT(KC_GRV),  \
+  LALT(KC_TAB),   LALT(KC_Q),  LALT(KC_W),  LALT(KC_E),  LALT(KC_R),  LALT(KC_T),  LALT(KC_Y),  LALT(KC_U),  LALT(KC_I),     LALT(KC_O),    LALT(KC_P),     LALT(KC_LBRC),  LALT(KC_RBRC),  LALT(KC_BSPC),  \
+  LALT(KC_LCTL),  KC_TRNS,     KC_TRNS,     LALT(KC_D),  LALT(KC_F),  LALT(KC_G),  LALT(KC_H),  LALT(KC_J),  LALT(KC_K),     LALT(KC_L),    LALT(KC_SCLN),  LALT(KC_QUOT),  KC_FN0,         \
+  KC_LSFT,        LALT(KC_Z),  LALT(KC_X),  LALT(KC_C),  LALT(KC_V),  LALT(KC_B),  LALT(KC_N),  LALT(KC_M),  LALT(KC_COMM),  LALT(KC_DOT),  LALT(KC_SLSH),  KC_RSFT,        KC_TRNS,        \
+      KC_LALT, KC_LGUI, LALT(KC_SPC),               KC_LGUI, KC_RALT),
+
+
+    /* Layer WIN: Win layer
+     |--------+---+---+---+---+---+---+---+---+---+---+-------+----------+-------+---|
+     | Esc    | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | -     | =        | \     | ` |
+     |--------+---+---+---+---+---+---+---+---+---+---+-------+----------+-------+---|
+     | Tab    | Q | W | E | R | T | Y | U | I | O | P | [     | ]        | Backs |   |
+     |--------+---+---+---+---+---+---+---+---+---+---+-------+----------+-------+---|
+     | Contro | A | S | D | F | G | H | J | K | L | ; | '     | RCtl/Ent |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+---+-------+----------+-------+---|
+     | Shift  | Z | X | C | V | B | N | M | , | . | / | Shift | Fn0      |       |   |
+     |--------+---+---+---+---+---+---+---+---+---+---+-------+----------+-------+---|
+
+                 |------+------+-------+------+------|
+                 | LGui | LAlt | Space | RGui | Ralt |
+                 |------+------+-------+------+------|
+    */
+
+  [WIN] = KEYMAP(  // BASE level with swapped GUI/ALT
+
+
+  KC_ESC,   KC_1,              KC_2,              KC_3,  KC_4,  KC_5,  KC_6,  KC_7,  KC_8,     KC_9,              KC_0,                 KC_MINS,  KC_EQL,    KC_BSLS,  KC_GRV,  \
+  KC_TAB,   KC_Q,              KC_W,              KC_E,  KC_R,  KC_T,  KC_Y,  KC_U,  KC_I,     KC_O,              KC_P,                 KC_LBRC,  KC_RBRC,   KC_BSPC,  \
+  KC_LCTL,  LT(LGUILEV,KC_A),  LT(LALTLEV,KC_S),  KC_D,  KC_F,  KC_G,  KC_H,  KC_J,  KC_K,     LT(RALTLEV,KC_L),  LT(RGUILEV,KC_SCLN),  KC_QUOT,  KC_FN0,    \
+  KC_LSFT,  KC_Z,              KC_X,              KC_C,  KC_V,  KC_B,  KC_N,  KC_M,  KC_COMM,  KC_DOT,            KC_SLSH,              KC_RSFT,  MO(HHKB),  \
+                 KC_RGUI, KC_RALT, KC_SPC,                KC_RALT, KC_RGUI)};
+
+
+const uint16_t PROGMEM fn_actions[] = {
+    [0] = ACTION_MODS_TAP_KEY(MOD_RCTL, KC_ENT)      // RControl with tap Enter*
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+          } else {
+            unregister_code(KC_RSFT);
+          }
+        break;
+      }
+    return MACRO_NONE;
+};

--- a/keyboard/hhkb_qmk/matrix.c
+++ b/keyboard/hhkb_qmk/matrix.c
@@ -1,0 +1,196 @@
+/*
+Copyright 2011 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+ * scan matrix
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <util/delay.h>
+#include "print.h"
+#include "debug.h"
+#include "util.h"
+#include "timer.h"
+#include "matrix.h"
+#include "hhkb_avr.h"
+#include <avr/wdt.h>
+#include "suspend.h"
+#include "lufa.h"
+
+
+// matrix power saving
+#define MATRIX_POWER_SAVE       10000
+static uint32_t matrix_last_modified = 0;
+
+// matrix state buffer(1:on, 0:off)
+static matrix_row_t *matrix;
+static matrix_row_t *matrix_prev;
+static matrix_row_t _matrix0[MATRIX_ROWS];
+static matrix_row_t _matrix1[MATRIX_ROWS];
+
+
+inline
+uint8_t matrix_rows(void)
+{
+    return MATRIX_ROWS;
+}
+
+inline
+uint8_t matrix_cols(void)
+{
+    return MATRIX_COLS;
+}
+
+void matrix_init(void)
+{
+#ifdef DEBUG
+    debug_enable = true;
+    debug_keyboard = true;
+#endif
+
+    KEY_INIT();
+
+    // initialize matrix state: all keys off
+    for (uint8_t i=0; i < MATRIX_ROWS; i++) _matrix0[i] = 0x00;
+    for (uint8_t i=0; i < MATRIX_ROWS; i++) _matrix1[i] = 0x00;
+    matrix = _matrix0;
+    matrix_prev = _matrix1;
+}
+
+uint8_t matrix_scan(void)
+{
+    uint8_t *tmp;
+
+    tmp = matrix_prev;
+    matrix_prev = matrix;
+    matrix = tmp;
+
+    // power on
+    if (!KEY_POWER_STATE()) KEY_POWER_ON();
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+            KEY_SELECT(row, col);
+            _delay_us(5);
+
+            // Not sure this is needed. This just emulates HHKB controller's behaviour.
+            if (matrix_prev[row] & (1<<col)) {
+                KEY_PREV_ON();
+            }
+            _delay_us(10);
+
+            // NOTE: KEY_STATE is valid only in 20us after KEY_ENABLE.
+            // If V-USB interrupts in this section we could lose 40us or so
+            // and would read invalid value from KEY_STATE.
+            uint8_t last = TIMER_RAW;
+
+            KEY_ENABLE();
+
+            // Wait for KEY_STATE outputs its value.
+            // 1us was ok on one HHKB, but not worked on another.
+            // no   wait doesn't work on Teensy++ with pro(1us works)
+            // no   wait does    work on tmk PCB(8MHz) with pro2
+            // 1us  wait does    work on both of above
+            // 1us  wait doesn't work on tmk(16MHz)
+            // 5us  wait does    work on tmk(16MHz)
+            // 5us  wait does    work on tmk(16MHz/2)
+            // 5us  wait does    work on tmk(8MHz)
+            // 10us wait does    work on Teensy++ with pro
+            // 10us wait does    work on 328p+iwrap with pro
+            // 10us wait doesn't work on tmk PCB(8MHz) with pro2(very lagged scan)
+            _delay_us(5);
+
+            if (KEY_STATE()) {
+                matrix[row] &= ~(1<<col);
+            } else {
+                matrix[row] |= (1<<col);
+            }
+
+            // Ignore if this code region execution time elapses more than 20us.
+            // MEMO: 20[us] * (TIMER_RAW_FREQ / 1000000)[count per us]
+            // MEMO: then change above using this rule: a/(b/c) = a*1/(b/c) = a*(c/b)
+            if (TIMER_DIFF_RAW(TIMER_RAW, last) > 20/(1000000/TIMER_RAW_FREQ)) {
+                matrix[row] = matrix_prev[row];
+            }
+
+            _delay_us(5);
+            KEY_PREV_OFF();
+            KEY_UNABLE();
+
+            // NOTE: KEY_STATE keep its state in 20us after KEY_ENABLE.
+            // This takes 25us or more to make sure KEY_STATE returns to idle state.
+#ifdef HHKB_JP
+            // Looks like JP needs faster scan due to its twice larger matrix
+            // or it can drop keys in fast key typing
+            _delay_us(30);
+#else
+            _delay_us(75);
+#endif
+        }
+        if (matrix[row] ^ matrix_prev[row]) matrix_last_modified = timer_read32();
+    }
+    // power off
+    if (KEY_POWER_STATE() &&
+            (USB_DeviceState == DEVICE_STATE_Suspended ||
+             USB_DeviceState == DEVICE_STATE_Unattached ) &&
+            timer_elapsed32(matrix_last_modified) > MATRIX_POWER_SAVE) {
+        KEY_POWER_OFF();
+        suspend_power_down();
+    }
+    return 1;
+}
+
+bool matrix_is_modified(void)
+{
+    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+        if (matrix[i] != matrix_prev[i])
+            return true;
+    }
+    return false;
+}
+
+inline
+bool matrix_has_ghost(void)
+{
+    return false;
+}
+
+inline
+bool matrix_is_on(uint8_t row, uint8_t col)
+{
+    return (matrix[row] & (1<<col));
+}
+
+inline
+matrix_row_t matrix_get_row(uint8_t row)
+{
+    return matrix[row];
+}
+
+void matrix_print(void)
+{
+    print("\nr/c 01234567\n");
+    for (uint8_t row = 0; row < matrix_rows(); row++) {
+        xprintf("%02X: %08b\n", row, bitrev(matrix_get_row(row)));
+    }
+}
+
+void matrix_power_up(void) {
+    KEY_POWER_ON();
+}
+void matrix_power_down(void) {
+    KEY_POWER_OFF();
+}


### PR DESCRIPTION
I migrated  my HHKB from original tmk to qmk firmware a couple of days ago and very pleased with the result so far. My favourite improvement is an increase in a number of actions to 4096. My keymap is much cleaner now. 
ergodox ez  keyboard is also great btw.  I received it in December but still adapting to the layout. 
