### PR TITLE
Single tap enable ACTION_LAYER_TAP_TOGGLE layer

### DIFF
--- a/keyboard/ergodox_ez/config.h
+++ b/keyboard/ergodox_ez/config.h
@@ -38,6 +38,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MOUSEKEY_MAX_SPEED      3
 #define MOUSEKEY_TIME_TO_MAX    10
 
+#define TAPPING_TOGGLE  1
+
 #define COLS (int []){ F1, F0, B0, C7, F4, F5, F6, F7, D4, D6, B4, D7 }
 #define ROWS (int []){ D0, D5, B5, B6 }
 


### PR DESCRIPTION
This is a simple change that may or may not be wanted but as I've been working on my layout I find it to be much better.

The current code requires that the "tmp coder layer" key be pressed 5 times to enable it using ACTION_LAYER_TAP_TOGGLE. This change makes it so it can be tapped to enable or disable or it can be held to use it temporarily.

I'm surprised that the change hadn't been made already but maybe there is a reason for it.