### PR TITLE
Disable Ergodox EZ debug console for improved performance

### DIFF
--- a/keyboard/ergodox_ez/Makefile
+++ b/keyboard/ergodox_ez/Makefile
@@ -93,7 +93,7 @@ OPT_DEFS += -DBOOTLOADER_SIZE=512
 BOOTMAGIC_ENABLE = yes # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE  = yes # Mouse keys(+4700)
 EXTRAKEY_ENABLE  = yes # Audio control and System control(+450)
-CONSOLE_ENABLE   = no # Console for debug(+400)
+# CONSOLE_ENABLE   = yes # Console for debug(+400)
 COMMAND_ENABLE   = yes # Commands for debug and configuration
 CUSTOM_MATRIX    = yes # Custom matrix file for the ErgoDox EZ
 SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend


### PR DESCRIPTION
Commenting out the line is the only way to disable the console, as the
value of CONSOLE_ENABLE isn't explicitly checked. There are only checks for its
existence (setting it to `yes` or `no` doesn't change anything).