### PR TITLE
Fix 2 macros in the Nordic keymap

### DIFF
--- a/quantum/keymap_extras/keymap_nordic.h
+++ b/quantum/keymap_extras/keymap_nordic.h
@@ -48,12 +48,12 @@
 #define NO_LBRC ALGR(KC_8)
 #define NO_RBRC ALGR(KC_9)
 #define NO_RCBR	ALGR(KC_0)
-#define NO_PIPE ALGR(NO_ACUT)
+#define NO_PIPE ALGR(KC_NUBS)
 
 #define NO_EURO ALGR(KC_E)
 #define NO_TILD ALGR(NO_QUOT)
 
-#define NO_BSLS ALGR(NO_LESS)
+#define NO_BSLS ALGR(KC_MINS)
 #define NO_MU 	ALGR(KC_M)
 
 #endif


### PR DESCRIPTION
By testing I found out that, at least on Linux using the Swedish layout,
two macros present on this file were wrong, for the backslash and pipe
keys. Jack helped me find the correct combination for the backslash and
that led me to the right one for pipe.