### PR TITLE
Added note about using avr_setup.sh

### DIFF
--- a/tmk_core/doc/build.md
+++ b/tmk_core/doc/build.md
@@ -6,7 +6,7 @@ Download and Install
 --------------------
 ### 1. Install Tools
 
-1. **Toolchain** On Windows install [MHV AVR Tools][mhv] for AVR GCC compiler and [Cygwin][cygwin](or [MinGW][mingw]) for shell terminal. On Mac you can use [CrossPack][crosspack]. On Linux you can install AVR GCC (and avr-libc) with your favorite package manager.
+1. **Toolchain** On Windows install [MHV AVR Tools][mhv] for AVR GCC compiler and [Cygwin][cygwin](or [MinGW][mingw]) for shell terminal. On Mac you can use [CrossPack][crosspack]. On Linux you can install AVR GCC (and avr-libc) with your favorite package manager or run the avr_setup.sh script in the root of this repository.
 
 2. **Programmer** On Windows install [Atmel FLIP][flip]. On Mac and Linux install [dfu-programmer][dfu-prog].
 


### PR DESCRIPTION
On most Linux distributions the avr_setup.sh script can be sourced ```. avr_setup.sh``` or under Bash ```source avr_setup.sh```. This will try and detect the appropriate package manager and install the required packages.