### PR TITLE
Add support for Atreus running on A-Star

### DIFF
--- a/keyboard/atreus/Makefile
+++ b/keyboard/atreus/Makefile
@@ -58,8 +58,13 @@ else
     SRC := keymaps/keymap_default.c $(SRC)
 endif
 
-ifdef ASTAR
+ifdef TEENSY2
+    OPT_DEFS += -DATREUS_TEENSY2
+    ATRUES_UPLOAD_COMMAND = teensy_loader_cli -w -mmcu=$(MCU) $(TARGET).hex
+else
     OPT_DEFS += -DATREUS_ASTAR
+    ATRUES_UPLOAD_COMMAND = while [ ! -r $(USB) ]; do sleep 1; done; \
+                            avrdude -p $(MCU) -c avr109 -U flash:w:$(TARGET).hex -P $(USB)
 endif
 
 CONFIG_H = config.h
@@ -144,9 +149,4 @@ include $(TOP_DIR)/quantum/quantum.mk
 USB ?= /dev/cu.usbmodem1411
 
 upload: build
-ifdef ASTAR
-	while [ ! -r $(USB) ]; do sleep 1; done; \
-		avrdude -p $(MCU) -c avr109 -U flash:w:$(TARGET).hex -P $(USB)
-else
-	teensy_loader_cli -w -mmcu=$(MCU) $(TARGET).hex
-endif
+	$(ATRUES_UPLOAD_COMMAND)

--- a/keyboard/atreus/Makefile
+++ b/keyboard/atreus/Makefile
@@ -58,6 +58,10 @@ else
     SRC := keymaps/keymap_default.c $(SRC)
 endif
 
+ifdef ASTAR
+    OPT_DEFS += -DATREUS_ASTAR
+endif
+
 CONFIG_H = config.h
 
 # MCU name
@@ -114,8 +118,8 @@ OPT_DEFS += -DBOOTLOADER_SIZE=4096
 #   comment out to disable the options.
 #
 #BOOTMAGIC_ENABLE = yes	# Virtual DIP switch configuration(+1000)
-#MOUSEKEY_ENABLE = yes	# Mouse keys(+4700)
-#EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
+MOUSEKEY_ENABLE = yes	# Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
 CONSOLE_ENABLE = yes	# Console for debug(+400)
 COMMAND_ENABLE = yes    # Commands for debug and configuration
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
@@ -137,3 +141,12 @@ VPATH += $(TMK_DIR)
 
 include $(TOP_DIR)/quantum/quantum.mk
 
+USB ?= /dev/cu.usbmodem1411
+
+upload: build
+ifdef ASTAR
+	while [ ! -r $(USB) ]; do sleep 1; done; \
+		avrdude -p $(MCU) -c avr109 -U flash:w:$(TARGET).hex -P $(USB)
+else
+	teensy_loader_cli -w -mmcu=$(MCU) $(TARGET).hex
+endif

--- a/keyboard/atreus/README.md
+++ b/keyboard/atreus/README.md
@@ -12,7 +12,7 @@ You have access to a bunch of goodies! Check out the Makefile to enable/disable 
 
 ## Atreus specific information
 
-These configuration files are specifically for the Atreus keyboards created by Phil Hagelberg (@technomancy). This keyboard is available in two variants: one powered by a Teensy 2, one powered by an A-Star. This repository currently assumes that you have a Teensy 2 powered Atreus. If you are using an A-Star, specify that by adding `ASTAR=yes` to your `make` commands.
+These configuration files are specifically for the Atreus keyboards created by Phil Hagelberg (@technomancy). This keyboard is available in two variants: one powered by a Teensy 2, one powered by an A-Star. This repository currently assumes that you have an A-Star powered Atreus. If you are using a Teensy2, specify that by adding `TEENSY2=yes` to your `make` commands.
 
 If you are coming from the [atreus-firmware](https://github.com/technomancy/atreus-firmware), we've also brought forward the `make upload` command for you to use.
 

--- a/keyboard/atreus/README.md
+++ b/keyboard/atreus/README.md
@@ -1,10 +1,6 @@
 atreus keyboard firmware
 ======================
 
-## Note
-
-This is for the Teensy2 hand wired boards only.
-
 ## Quantum MK Firmware
 
 You have access to a bunch of goodies! Check out the Makefile to enable/disable some of the features. Uncomment the `#` to enable them. Setting them to `no` does nothing and will only confuse future you.
@@ -13,6 +9,12 @@ You have access to a bunch of goodies! Check out the Makefile to enable/disable 
     MIDI_ENABLE = yes      # MIDI controls
     # UNICODE_ENABLE = yes # Unicode support - this is commented out, just as an example. You have to use #, not //
     BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
+
+## Atreus specific information
+
+These configuration files are specifically for the Atreus keyboards created by Phil Hagelberg (@technomancy). This keyboard is available in two variants: one powered by a Teensy 2, one powered by an A-Star. This repository currently assumes that you have a Teensy 2 powered Atreus. If you are using an A-Star, specify that by adding `ASTAR=yes` to your `make` commands.
+
+If you are coming from the [atreus-firmware](https://github.com/technomancy/atreus-firmware), we've also brought forward the `make upload` command for you to use.
 
 ## Quick aliases to common actions
 

--- a/keyboard/atreus/atreus.h
+++ b/keyboard/atreus/atreus.h
@@ -7,21 +7,20 @@
 #include <stddef.h>
 
 // This a shortcut to help you visually see your layout.
-// The following is an example using the Planck MIT layout
 // The first section contains all of the arguements
 // The second converts the arguments into a two-dimensional array
 #define KEYMAP( \
-	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, \
-	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, \
-	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, \
-	k30, k31, k32, k33, k34,    k35,   k37, k38, k39, k3a, k3b \
+  k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, \
+  k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, \
+  k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, \
+  k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a \
 ) \
 { \
-	{ k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b }, \
-	{ k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b }, \
-	{ k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b }, \
-	{ k30, k31, k32, k33, k34, k35, k35, k37, k38, k39, k3a, k3b } \
-} 
+	{ k00, k01, k02, k03, k04, KC_NO, k05, k06, k07, k08, k09 }, \
+	{ k10, k11, k12, k13, k14, KC_NO, k15, k16, k17, k18, k19 }, \
+	{ k20, k21, k22, k23, k24, k35,   k25, k26, k27, k28, k29 }, \
+	{ k2a, k30, k31, k32, k33, k34,   k36, k37, k38, k39, k3a } \
+}
 
 void * matrix_init_user(void);
 void * matrix_scan_user(void);

--- a/keyboard/atreus/config.h
+++ b/keyboard/atreus/config.h
@@ -33,11 +33,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 4
 #define MATRIX_COLS 11
 
-// Planck PCB default pin-out
 // Change this to how you wired your keyboard
 // COLS: Left to right, ROWS: Top to bottom
-#define COLS (int []){ F6, F5, F4, B7, B6, B5, B4, B3, B2, B1, B0}
-#define ROWS (int []){ D0, D1, D2, D3 }
+#ifdef ATREUS_ASTAR
+  #define COLS (int []){ B7, D6, F7, F6, B6, D4, E6, B4, B5, C6, D7 }
+  #define ROWS (int []){ D0, D1, D3, D2 }
+#else
+  #define COLS (int []){ F6, F5, F4, B7, B6, B5, B4, B3, B2, B1, B0}
+  #define ROWS (int []){ D0, D1, D2, D3 }
+#endif
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW

--- a/keyboard/atreus/config.h
+++ b/keyboard/atreus/config.h
@@ -35,10 +35,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Change this to how you wired your keyboard
 // COLS: Left to right, ROWS: Top to bottom
-#ifdef ATREUS_ASTAR
+#if defined(ATREUS_ASTAR)
   #define COLS (int []){ B7, D6, F7, F6, B6, D4, E6, B4, B5, C6, D7 }
   #define ROWS (int []){ D0, D1, D3, D2 }
-#else
+#elif defined(ATREUS_TEENSY2)
   #define COLS (int []){ F6, F5, F4, B7, B6, B5, B4, B3, B2, B1, B0}
   #define ROWS (int []){ D0, D1, D2, D3 }
 #endif

--- a/keyboard/atreus/keymaps/keymap_gerb.c
+++ b/keyboard/atreus/keymaps/keymap_gerb.c
@@ -1,0 +1,66 @@
+// This is the personal keymap of Chris Gerber (@gerbercj). I haven't worked out the kinks
+// with the Colemak and Dvorak support yet, but everything else works nicely.
+
+#include "atreus.h"
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _QW 0
+#define _CM 1
+#define _DV 2
+#define _L1 3
+#define _L2 4
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_QW] = { /* Qwerty */
+    {KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_NO,   KC_Y,    KC_U,    KC_I,    KC_O,    KC_P   },
+    {KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_NO,   KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN},
+    {KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_LALT, KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH},
+    {KC_ESC,  KC_TAB,  KC_LGUI, KC_LSFT, KC_BSPC, KC_RCTL, KC_SPC,  MO(_L1), KC_MINS, KC_QUOT, KC_ENT }
+  },
+  [_CM] = { /* Colemak */
+    {KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_NO,   KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN},
+    {KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_NO,   KC_H,    KC_N,    KC_E,    KC_I,    KC_O   },
+    {KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_LALT, KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH},
+    {KC_ESC,  KC_TAB,  KC_LGUI, KC_LSFT, KC_BSPC, KC_RCTL, KC_SPC,  MO(_L1), KC_MINS, KC_QUOT, KC_ENT }
+  },
+  [_DV] = { /* Dvorak */
+    {KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_NO,   KC_F,    KC_G,    KC_C,    KC_R,    KC_L   },
+    {KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_NO,   KC_D,    KC_H,    KC_T,    KC_N,    KC_S   },
+    {KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_LALT, KC_B,    KC_M,    KC_W,    KC_V,    KC_Z   },
+    {KC_ESC,  KC_TAB,  KC_LGUI, KC_LSFT, KC_BSPC, KC_RCTL, KC_SPC,  MO(_L1), KC_MINS, KC_SLSH, KC_ENT }
+  },
+  [_L1] = { /* LAYER 1 */
+    {KC_INS,  KC_HOME, KC_UP,   KC_END,  KC_PGUP, KC_NO,   KC_VOLU, KC_7,    KC_8,    KC_9,    KC_LBRC},
+    {KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN, KC_NO,   KC_VOLD, KC_4,    KC_5,    KC_6,    KC_RBRC},
+    {KC_GRV,  KC_MPRV, KC_MPLY, KC_MNXT, KC_MINS, KC_LALT, KC_MUTE, KC_1,    KC_2,    KC_3,    KC_BSLS},
+    {TG(_L2), KC_APP,  KC_LGUI, KC_LSFT, KC_BSPC, KC_RCTL, KC_SPC,  KC_TRNS, KC_DOT,  KC_0,    KC_EQL }
+  },
+  [_L2] = { /* LAYER 2 */
+    {KC_TRNS, KC_WH_L, KC_MS_U, KC_WH_R, KC_WH_U, KC_NO,   DF(_QW), KC_F7,   KC_F8,   KC_F9,   KC_F10 },
+    {KC_TRNS, KC_MS_L, KC_MS_D, KC_MS_R, KC_WH_D, KC_NO,   DF(_CM), KC_F6,   KC_F5,   KC_F6,   KC_F11 },
+    {KC_BTN4, KC_BTN1, KC_BTN2, KC_BTN3, KC_BTN4, KC_LALT, DF(_DV), KC_F1,   KC_F2,   KC_F3,   KC_F12 },
+    {KC_TRNS, KC_TRNS, KC_LGUI, KC_LSFT, KC_BSPC, KC_RCTL, KC_SPC,  KC_TRNS, KC_TRNS, KC_TRNS, RESET  }
+  }
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function
+      switch(id) {
+        case 0:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+          } else {
+            unregister_code(KC_RSFT);
+          }
+        break;
+      }
+    return MACRO_NONE;
+};

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -91,6 +91,9 @@ action_t action_for_key(uint8_t layer, keypos_t key)
             play_notes(&goodbye, 5, false);
         #endif
         _delay_ms(250);
+        #ifdef ATREUS_ASTAR
+            *(uint16_t *)0x0800 = 0x7777; // these two are a-star-specific
+        #endif
         bootloader_jump();
         return;
     } else if (keycode == DEBUG) { // DEBUG is 0x5001


### PR DESCRIPTION
This pull request is to add support for A-Star based Atreus keyboards, in addition to the existing support for the Teensy 2 based version. It also includes the following:
 * support for `make upload`, like in [atreus-firmware](https://github.com/technomancy/atreus-firmware)
 * my personal keymap

When targeting an A-Star, add `ASTAR=yes` to your `make` commands.

@seancaffery
/cc @jackhumbert @technomancy