### PR TITLE
Include Dvorak underscore and plus keys.

### DIFF
--- a/quantum/keymap_extras/keymap_dvorak.h
+++ b/quantum/keymap_extras/keymap_dvorak.h
@@ -68,5 +68,7 @@
 #define DV_RPRN	LSFT(DV_0)
 #define DV_LCBR	LSFT(DV_LBRC)
 #define DV_RCBR	LSFT(DV_RBRC)
+#define DV_UNDS LSFT(DV_MINS)
+#define DV_PLUS LSFT(DV_EQL)
 
 #endif


### PR DESCRIPTION
There were previously no Dvorak specific underscore and plus key codes. For a keyboard like the Planck which has layers directly to shifted versions of special character keys you were unable to produce those characters using the Lower layer.