### PR TITLE
Fix FR_RCBR declaration in keymap_french.h

### DIFF
--- a/quantum/keymap_extras/keymap_french.h
+++ b/quantum/keymap_extras/keymap_french.h
@@ -75,7 +75,7 @@
 #define FR_CIRC	ALGR(KC_9)
 #define FR_AT 	ALGR(KC_0)
 #define FR_RBRC	ALGR(FR_RPRN)
-#define FR_LCBR ALGR(FR_EQL)
+#define FR_RCBR ALGR(FR_EQL)
 
 #define FR_EURO	ALGR(KC_E)
 #define FR_BULT	ALGR(FR_DLR)


### PR DESCRIPTION
Hi,

This PR fix a missing declaration of FR_RCBR and remove a duplicate declaration of FR_LCBR in keymap_french.h