### PR TITLE
Fix #156: clear weak mods on every key press

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -70,6 +70,10 @@ void process_action(keyrecord_t *record)
 #endif
     dprintln();
 
+    if (event.pressed) {
+        // clear the potential weak mods left by previously pressed keys
+        clear_weak_mods();
+    }
     switch (action.kind.id) {
         /* Key and Mods */
         case ACT_LMODS:
@@ -500,6 +504,7 @@ void clear_keyboard(void)
 void clear_keyboard_but_mods(void)
 {
     clear_weak_mods();
+    clear_macro_mods();
     clear_keys();
     send_keyboard_report();
 #ifdef MOUSEKEY_ENABLE

--- a/tmk_core/common/action_macro.c
+++ b/tmk_core/common/action_macro.c
@@ -41,7 +41,7 @@ void action_macro_play(const macro_t *macro_p)
                 MACRO_READ();
                 dprintf("KEY_DOWN(%02X)\n", macro);
                 if (IS_MOD(macro)) {
-                    add_weak_mods(MOD_BIT(macro));
+                    add_macro_mods(MOD_BIT(macro));
                     send_keyboard_report();
                 } else {
                     register_code(macro);
@@ -51,7 +51,7 @@ void action_macro_play(const macro_t *macro_p)
                 MACRO_READ();
                 dprintf("KEY_UP(%02X)\n", macro);
                 if (IS_MOD(macro)) {
-                    del_weak_mods(MOD_BIT(macro));
+                    del_macro_mods(MOD_BIT(macro));
                     send_keyboard_report();
                 } else {
                     unregister_code(macro);

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -29,6 +29,7 @@ static inline void del_key_bit(uint8_t code);
 
 static uint8_t real_mods = 0;
 static uint8_t weak_mods = 0;
+static uint8_t macro_mods = 0;
 
 #ifdef USB_6KRO_ENABLE
 #define RO_ADD(a, b) ((a + b) % KEYBOARD_REPORT_KEYS)
@@ -55,6 +56,7 @@ static int16_t oneshot_time = 0;
 void send_keyboard_report(void) {
     keyboard_report->mods  = real_mods;
     keyboard_report->mods |= weak_mods;
+    keyboard_report->mods |= macro_mods;
 #ifndef NO_ACTION_ONESHOT
     if (oneshot_mods) {
 #if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
@@ -117,6 +119,13 @@ void add_weak_mods(uint8_t mods) { weak_mods |= mods; }
 void del_weak_mods(uint8_t mods) { weak_mods &= ~mods; }
 void set_weak_mods(uint8_t mods) { weak_mods = mods; }
 void clear_weak_mods(void) { weak_mods = 0; }
+
+/* macro modifier */
+uint8_t get_macro_mods(void) { return macro_mods; }
+void add_macro_mods(uint8_t mods) { macro_mods |= mods; }
+void del_macro_mods(uint8_t mods) { macro_mods &= ~mods; }
+void set_macro_mods(uint8_t mods) { macro_mods = mods; }
+void clear_macro_mods(void) { macro_mods = 0; }
 
 /* Oneshot modifier */
 #ifndef NO_ACTION_ONESHOT

--- a/tmk_core/common/action_util.h
+++ b/tmk_core/common/action_util.h
@@ -47,6 +47,13 @@ void del_weak_mods(uint8_t mods);
 void set_weak_mods(uint8_t mods);
 void clear_weak_mods(void);
 
+/* macro modifier */
+uint8_t get_macro_mods(void);
+void add_macro_mods(uint8_t mods);
+void del_macro_mods(uint8_t mods);
+void set_macro_mods(uint8_t mods);
+void clear_macro_mods(void);
+
 /* oneshot modifier */
 void set_oneshot_mods(uint8_t mods);
 void clear_oneshot_mods(void);


### PR DESCRIPTION
Fix for #156:
- new `macro_mods` bit field for mods applied by macros – implementation is exactly the same as `weak_mods` used to be;
- `weak_mods` is now only used for `ACT_`{`L`,`R`}`MODS` (i.e. `LSFT`, `RSFT`, `LCTL` etc.);
- clear `weak_mods` on every key **pressed** such that `LSFT` etc. can no more interfere with the next key.