### PR TITLE
Add important note about brightness on OS X

### DIFF
--- a/keyboard/ergodox_ez/keymaps/romanzolotarev-norman-plover-osx/readme.md
+++ b/keyboard/ergodox_ez/keymaps/romanzolotarev-norman-plover-osx/readme.md
@@ -28,7 +28,11 @@ There are four layers:
 - Tap `F2` to copy screenshot to the clipboard.
 - Hold `SHIFT` and tap `F2` to save screenshot as a file.
 - Tap `F3`, `F4`, `F5`, `F6` to resize a window via [Divvy](http://mizage.com/divvy/).
-- Tap `F14`, `F15` to adjust display brightness.
+- Tap `F14`, `F15` to adjust display brightness. 
+
+**IMPORTANT**: If you have another keyboard connected via Bluetooth, then `F14` and `F15` will not work.
+Turn off that Bluetooth keyboard. Re-plug you ErgoDox. Enjoy!
+
 
 ## CTRL/ESC
 


### PR DESCRIPTION
@jackhumbert @ezuk @jeffschenck Seems like I found how to fix that weird case with display brightness on OS X.

While I'm still re-learning to type on ErgoDox, I switch to my Apple Wireless keyboard during the day and then switch back to ErgoDox at the end of the day. So when that Bluetooth keyboard is still connected, `F14` and `F15` keycodes (which ErgoDox sends correctly) do not work on OS X as expected.

Could you please confirm?

*Case A*

1. Plug-in your ErgoDox via USB to your Mac (OS X)
2. Connect Apple Wireless via Bluetooth
3. Tap `F14` and `F15` on ErgoDox

Expected result: Display brightness stays unchanged. Feels weird.

*Case B*

1. Disconnect Apple Wireless, if it was connected
2. Unplug ErgoDox from USB of your Mac
3. Plug ErgoDox in
4. Tap `F14` and `F15` on ErgoDox

Expected result: Display brightness has changed. Feels great.