### PR TITLE
Add per-event user hook function

### DIFF
--- a/keyboard/planck/planck.c
+++ b/keyboard/planck/planck.c
@@ -1,32 +1,34 @@
 #include "planck.h"
 
 __attribute__ ((weak))
-void matrix_init_user(void) {
-
-}
+void matrix_init_user(void) {}
 
 __attribute__ ((weak))
-void matrix_scan_user(void) {
+void matrix_scan_user(void) {}
 
-}
+__attribute__ ((weak))
+void process_action_user(keyrecord_t *record) {}
 
 void matrix_init_kb(void) {
-	#ifdef BACKLIGHT_ENABLE
-    	backlight_init_ports();
-	#endif
+#ifdef BACKLIGHT_ENABLE
+	backlight_init_ports();
+#endif
 
-	#ifdef RGBLIGHT_ENABLE
-		rgblight_init();
-	#endif
+#ifdef RGBLIGHT_ENABLE
+	rgblight_init();
+#endif
 
-
-    // Turn status LED on
-    DDRE |= (1<<6);
-    PORTE |= (1<<6);
+	// Turn status LED on
+	DDRE |= (1<<6);
+	PORTE |= (1<<6);
 
 	matrix_init_user();
 }
 
 void matrix_scan_kb(void) {
 	matrix_scan_user();
+}
+
+void process_action_kb(keyrecord_t *record) {
+	process_action_user(record);
 }

--- a/keyboard/planck/planck.h
+++ b/keyboard/planck/planck.h
@@ -42,5 +42,6 @@
 
 void matrix_init_user(void);
 void matrix_scan_user(void);
+void process_action_user(keyrecord_t *record);
 
 #endif

--- a/quantum/template/template.c
+++ b/quantum/template/template.c
@@ -11,6 +11,11 @@ void matrix_scan_user(void) {
 }
 
 __attribute__ ((weak))
+void process_action_user(keyrecord_t *record) {
+	// leave this function blank - it can be defined in a keymap file
+}
+
+__attribute__ ((weak))
 void led_set_user(uint8_t usb_led) {
 	// leave this function blank - it can be defined in a keymap file
 }
@@ -18,15 +23,22 @@ void led_set_user(uint8_t usb_led) {
 void matrix_init_kb(void) {
 	// put your keyboard start-up code here
 	// runs once when the firmware starts up
-	
+
 	matrix_init_user();
 }
 
 void matrix_scan_kb(void) {
-    // put your looping keyboard code here
-    // runs every cycle (a lot)
+	// put your looping keyboard code here
+	// runs every cycle (a lot)
 
 	matrix_scan_user();
+}
+
+void process_action_kb(keyrecord_t *record) {
+	// put your per-action keyboard code here
+	// runs for every action, just before processing by the firmware
+
+	process_action_user(record);
 }
 
 void led_set_kb(uint8_t usb_led) {

--- a/quantum/template/template.h
+++ b/quantum/template/template.h
@@ -17,10 +17,11 @@
 { \
     { k00, k01,   k02 }, \
     { k10, KC_NO, k11 }, \
-} 
+}
 
 void matrix_init_user(void);
 void matrix_scan_user(void);
+void process_action_user(keyrecord_t *record);
 void led_set_user(uint8_t usb_led);
 
 #endif

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -54,7 +54,7 @@ void action_exec(keyevent_t event)
 }
 
 __attribute__ ((weak))
-void process_action_user(keyrecord_t *record) {}
+void process_action_kb(keyrecord_t *record) {}
 
 void process_action(keyrecord_t *record)
 {
@@ -65,7 +65,7 @@ void process_action(keyrecord_t *record)
 
     if (IS_NOEVENT(event)) { return; }
 
-    process_action_user(record);
+    process_action_kb(record);
 
     action_t action = layer_switch_get_action(event.key);
     dprint("ACTION: "); debug_action(action);

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -53,6 +53,9 @@ void action_exec(keyevent_t event)
 #endif
 }
 
+__attribute__ ((weak))
+void process_action_user(keyrecord_t *record) {}
+
 void process_action(keyrecord_t *record)
 {
     keyevent_t event = record->event;
@@ -61,6 +64,8 @@ void process_action(keyrecord_t *record)
 #endif
 
     if (IS_NOEVENT(event)) { return; }
+
+    process_action_user(record);
 
     action_t action = layer_switch_get_action(event.key);
     dprint("ACTION: "); debug_action(action);

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -58,6 +58,9 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt);
 /* user defined special function */
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt);
 
+/* user-defined (pre)processing of each key event */
+void process_action_user(keyrecord_t *record);
+
 /* Utilities for actions.  */
 void process_action(keyrecord_t *record);
 void register_code(uint8_t code);

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -58,8 +58,8 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt);
 /* user defined special function */
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt);
 
-/* user-defined (pre)processing of each key event */
-void process_action_user(keyrecord_t *record);
+/* keyboard-specific key event (pre)processing */
+void process_action_kb(keyrecord_t *record);
 
 /* Utilities for actions.  */
 void process_action(keyrecord_t *record);


### PR DESCRIPTION
This adds a call to a `process_action_user(event)` hook function before
each key event is handled. A weak noop implementation is provided, so
that it can be overridden in user-specific code. A use case would be to
make the backlight react to typing, for instance.

I [asked for suggestions][reddit] some time ago but in the end it was
much cleaner to make this modification to the common code.

See #57

[reddit]: https://www.reddit.com/r/olkb/comments/4939wn/how_to_cleanly_redefine_action_exec_or_process/