### PR TITLE
Master

### DIFF
--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "debug.h"
 #include "backlight.h"
 #include "keymap_midi.h"
+#include "bootloader.h"
 
 #include <stdio.h>
 #include <inttypes.h>

--- a/quantum/template/config.h
+++ b/quantum/template/config.h
@@ -32,36 +32,67 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 2
 #define MATRIX_COLS 3
 
-// Planck PCB default pin-out
-// Change this to how you wired your keyboard
-// COLS: Left to right, ROWS: Top to bottom
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *                  ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+*/ 
 #define COLS (int []){ F1, F0, B0 }
 #define ROWS (int []){ D0, D5 }
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
-/* define if matrix has ghost */
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCE    5
+
+/* define if matrix has ghost (lacks anti-ghosting diodes) */
 //#define MATRIX_HAS_GHOST
 
 /* number of backlight levels */
 #define BACKLIGHT_LEVELS 3
-
-/* Set 0 if debouncing isn't needed */
-#define DEBOUNCE    5
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
 
-/* Force NKRO Mode - If forced on, must be disabled via magic key (default = LShift+RShift+N) */
+/* 
+ * Force NKRO
+ *
+ * Force NKRO (nKey Rollover) to be enabled by default, regardless of the saved 
+ * state in the bootmagic EEPROM settings. (Note that NKRO must be enabled in the
+ * makefile for this to work.)
+ *
+ * If forced on, NKRO can be disabled via magic key (default = LShift+RShift+N)
+ * until the next keyboard reset.
+ *
+ * NKRO may prevent your keystrokes from being detected in the BIOS, but it is 
+ * fully operational during normal computer usage.
+ *
+ * For a less heavy-handed approach, enable NKRO via magic key (LShift+RShift+N)
+ * or via bootmagic (hold SPACE+N while plugging in the keyboard). Once set by
+ * bootmagic, NKRO mode will always be enabled until it is toggled again during a
+ * power-up.
+ *
+ */
 //#define FORCE_NKRO
 
 /*
- * Magic key options
- * These options allow the magic key functionality to be changed. This is useful
- * if your keyboard/keypad is missing keys and you want magic key support.
+ * Magic Key Options
+ *
+ * Magic keys are hotkey commands that allow control over firmware functions of
+ * the keyboard. They are best used in combination with the HID Listen program,
+ * found here: https://www.pjrc.com/teensy/hid_listen.html
+ *
+ * The options below allow the magic key functionality to be changed. This is 
+ * useful if your keyboard/keypad is missing keys and you want magic key support.
+ *
  */
 
 /* key combination for magic key command */

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -66,8 +66,11 @@ static void power_down(uint8_t wdto)
     wdt_intr_enable(wdto);
 
 #ifdef BACKLIGHT_ENABLE
-backlight_set(0);
+	backlight_set(0);
 #endif
+
+	// Turn off LED indicators
+	led_set(0);
 
     // TODO: more power saving
     // See PicoPower application note

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -92,7 +92,7 @@ void keyboard_init(void)
     backlight_init();
 #endif
 
-#ifdef FORCE_NKRO
+#if defined(NKRO_ENABLE) && defined(FORCE_NKRO)
 	keyboard_nkro = true;
 #endif
 


### PR DESCRIPTION
Keyboard indicator LEDs are turned off while the host PC is asleep.

Fixed compiler warning by including bootloader.h in keymap_common.c. 

Changed FORCE_NKRO to only be applied if NKRO_ENABLE is defined.

Added extra documentation to the template config.h. (Thanks, Jack, for turning QMK into QMEasymode!)