### PR TITLE
Fix error in Planck makefile comment

### DIFF
--- a/keyboard/planck/Makefile
+++ b/keyboard/planck/Makefile
@@ -143,7 +143,7 @@ BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 # AUDIO_ENABLE = YES 		# Audio output on port C6
 # UNICODE_ENABLE = YES 		# Unicode
 # BLUETOOTH_ENABLE = yes # Enable Bluetooth with the Adafruit EZ-Key HID
-# RGBLIGHT_ENABLE = yes # Enable WS2812 RGB underlight.  Do not enable this with MIDI at the same time.
+# RGBLIGHT_ENABLE = yes # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 
 ifdef BACKLIGHT_ENABLE
 	SRC += backlight.c


### PR DESCRIPTION
[This comment](https://www.reddit.com/r/olkb/comments/428umx/rgb_underglow/czaivbc) states that because both audio output and RGB support require the user of timer 3, they can't be enabled at the same time. That makes sense, I can see where audio.c uses timer 3. But this comment in the code states that the incompatibility is with MIDI support, which doesn't make sense based on what I see in the code. Please enlighten me if I'm mistaken.