### PR TITLE
Fixed filename for teensy-loader-cli in rules.mk

### DIFF
--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -412,7 +412,7 @@ program: $(TARGET).hex $(TARGET).eep
 	$(PROGRAM_CMD)
 
 teensy: $(TARGET).hex
-	teensy_loader_cli -mmcu=$(MCU) -w -v $(TARGET).hex
+	teensy-loader-cli -mmcu=$(MCU) -w -v $(TARGET).hex
 
 flip: $(TARGET).hex
 	batchisp -hardware usb -device $(MCU) -operation erase f


### PR DESCRIPTION
Changed underscores to dashes in  `teensy-loader-cli` to match actual file name, line 415.  

Without this change, I cannot use the option `make teensy` because the filename with underscores does not exist. 