### PR TITLE
Fix issue #221: LGUI(KC_LSFT) does not work

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -88,14 +88,24 @@ void process_action(keyrecord_t *record)
                                                                 action.key.mods<<4;
                 if (event.pressed) {
                     if (mods) {
-                        add_weak_mods(mods);
+                        if (IS_MOD(action.key.code)) {
+                            // e.g. LSFT(KC_LGUI): we don't want the LSFT to be weak as it would make it useless.
+                            // this also makes LSFT(KC_LGUI) behave exactly the same as LGUI(KC_LSFT)
+                            add_mods(mods);
+                        } else {
+                            add_weak_mods(mods);
+                        }
                         send_keyboard_report();
                     }
                     register_code(action.key.code);
                 } else {
                     unregister_code(action.key.code);
                     if (mods) {
-                        del_weak_mods(mods);
+                        if (IS_MOD(action.key.code)) {
+                            del_mods(mods);
+                        } else {
+                            del_weak_mods(mods);
+                        }
                         send_keyboard_report();
                     }
                 }


### PR DESCRIPTION
Fixes #221 by registering `LGUI`, `LSFT` etc. on mod keys as normal mods instead of weak mods:
 - they won't be cleared when pressing another key (#188)
 - they won't be cleared by layer switching
 - `LSFT(KC_LGUI)` will now have the same behavior as `LGUI(KC_LSFT)`