### PR TITLE
Add KC_LABK and KC_RABK (< and >)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The following shortcuts automatically add `LSFT()` to keycodes to get commonly u
     KC_PLUS  +
     KC_LCBR  {
     KC_RCBR  }
+    KC_LABK  <
+    KC_RABK  >
     KC_PIPE  |
     KC_COLN  :
 

--- a/keyboard/ergodox_ez/keymaps/zweihander-osx/keymap.c
+++ b/keyboard/ergodox_ez/keymaps/zweihander-osx/keymap.c
@@ -109,8 +109,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                        |      |      |       |      |      |
  *                                 ,------|------|------|       |------+------+------.
  *                                 |      |      |      |       |      |      |      |
- *                                 |      |      |------|       |------|      |      |
- *                                 |      |      |      |       |      |      |      |
+ *                                 |      |      |------|       |------|  ⌘C  |  ⌘V  |
+ *                                 |      |      |      |       |  ⌘X  |      |      |
  *                                 `--------------------'       `--------------------'
  */
 // MEDIA AND MOUSE
@@ -129,9 +129,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                     LGUI(KC_LBRC),  KC_LEFT,            KC_DOWN,        KC_RGHT,                KC_TRNS,        KC_MPLY,
        KC_TRNS,     LSFT(KC_SPC),   KC_SPC ,            KC_MPRV,        KC_MNXT,                KC_TRNS,        KC_TRNS,
                                     KC_VOLU,            KC_VOLD,        KC_MUTE,                KC_TRNS,        KC_TRNS,
-       KC_TRNS, KC_TRNS,
+       KC_TRNS,     KC_TRNS,
        KC_TRNS,
-       KC_TRNS, KC_TRNS, KC_TRNS
+       LGUI(KC_X),  LGUI(KC_C),     LGUI(KC_V)
 ),
 };
 

--- a/keyboard/ergodox_ez/keymaps/zweihander-osx/keymap.c
+++ b/keyboard/ergodox_ez/keymaps/zweihander-osx/keymap.c
@@ -55,11 +55,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * ,--------------------------------------------------.           ,--------------------------------------------------.
  * |        |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
  * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
- * |        |   !  |   @  |   {  |   }  |   |  |      |           |      |   /  |   7  |   8  |   9  |   *  |   F12  |
+ * |        |   [  |   ]  |   {  |   }  |      |      |           |      |   /  |   7  |   8  |   9  |   *  |   F12  |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |   #  |   $  |   (  |   )  |   `  |------|           |------|   -  |   4  |   5  |   6  |   +  |        |
+ * |        |   <  |   >  |   (  |   )  |      |------|           |------|   -  |   4  |   5  |   6  |   +  |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |   &  |   1  |   2  |   3  |   =  |        |
+ * |        |      |      |      |      |      |      |           |      |   &  |   1  |   2  |   3  |   =  |        |
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
  *   |      |      |      |      |      |                                       |   0  |   .  |   ←  |   →  |      |
  *   `----------------------------------'                                       `----------------------------------'
@@ -75,9 +75,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [SYMB] = KEYMAP(
        // left hand
        KC_TRNS,KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
-       KC_TRNS,KC_EXLM,KC_AT,  KC_LCBR,KC_RCBR,KC_PIPE,KC_TRNS,
-       KC_TRNS,KC_HASH,KC_DLR, KC_LPRN,KC_RPRN,KC_GRV,
-       KC_TRNS,KC_PERC,KC_CIRC,KC_LBRC,KC_RBRC,KC_TILD,KC_TRNS,
+       KC_TRNS,KC_LBRC,KC_RBRC,KC_LCBR,KC_RCBR,KC_TRNS,KC_TRNS,
+       KC_TRNS,KC_LABK,KC_RABK,KC_LPRN,KC_RPRN,KC_TRNS,
+       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
        KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
                                        KC_TRNS,KC_TRNS,
                                                KC_TRNS,

--- a/quantum/keymap_common.h
+++ b/quantum/keymap_common.h
@@ -118,6 +118,12 @@ extern const uint16_t fn_actions[];
 #define KC_RCBR LSFT(KC_RBRC)   // }
 #define KC_RIGHT_CURLY_BRACE    KC_RCBR
 
+#define KC_LABK LSFT(KC_COMM)   // <
+#define KC_LEFT_ANGLE_BRACKET   KC_LABK
+
+#define KC_RABK LSFT(KC_DOT)    // >
+#define KC_RIGHT_ANGLE_BRACKET  KC_RABK
+
 #define KC_COLN LSFT(KC_SCLN)   // :
 #define KC_COLON    KC_COLN
 


### PR DESCRIPTION
I wanted angle brackets on my keyboard, so I added KC_ aliases for them in keymap_common.h.

Also adds minor updates to zweihander_osx.