### PR TITLE
Squash the prototype compiler warning

### DIFF
--- a/keyboard/ergodox_ez/matrix.c
+++ b/keyboard/ergodox_ez/matrix.c
@@ -50,7 +50,7 @@ static matrix_row_t matrix_debouncing[MATRIX_ROWS];
 
 static matrix_row_t read_cols(uint8_t row);
 static void init_cols(void);
-static void unselect_rows();
+static void unselect_rows(void);
 static void select_row(uint8_t row);
 
 static uint8_t mcp23018_reset_loop;


### PR DESCRIPTION
unselect_rows declared with no parameter list; requires (void) to
prevent compiler warning