### PR TITLE
Add a Travis recipe.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+os:
+  - linux
+
+language:
+  - c
+
+compiler:
+  - avr-gcc
+
+env:
+  - KEYBOARD=alps64
+  - KEYBOARD=arrow_pad
+  - KEYBOARD=atomic
+  - KEYBOARD=atreus
+  - KEYBOARD=bantam44
+  - KEYBOARD=clueboard1
+  - KEYBOARD=clueboard2
+  - KEYBOARD=cluepad
+  - KEYBOARD=ergodox_ez
+  - KEYBOARD=gh60
+  - KEYBOARD=gh60_rev_c
+  - KEYBOARD=hhkb
+  - KEYBOARD=jd45
+  - KEYBOARD=kc60_v2
+  - KEYBOARD=planck
+  - KEYBOARD=preonic
+  - KEYBOARD=retro_refit
+
+script:
+  - cd keyboard/$KEYBOARD && make
+
+addons:
+  apt:
+    packages:
+      - avr-libc
+      - gcc-avr
+      - dfu-programmer


### PR DESCRIPTION
There we go, dfu-programmer finally whitelisted, so this is running in container mode, starting directly. 

Once merged, enable the triggers for your github repository, including pull requests, maybe a travis-badge for the top-level README.md. A future improvement might be to add new keyboards created via new_project.sh to .travis.yml, but expressing that in shell script is left as an exercise to the reader.

The choice to go with env for each keyboard is to make it leaner to the eye to spot what target broke due to some change. Hopefully not that much of an effort to keep the list up to date.

Another future improvement might be to build with -Werror, so pull requests that introduce warnings will be marked as errors in the github interface. There are warnings in the code already so fixing them first is probably the best way forward. 