### PR TITLE
Move LED strip initialization

### DIFF
--- a/keyboard/clueboard1/clueboard1.c
+++ b/keyboard/clueboard1/clueboard1.c
@@ -11,10 +11,6 @@ void matrix_scan_user(void) {
 }
 
 void matrix_init_kb(void) {
-	#ifdef RGBLIGHT_ENABLE
-		rgblight_init();
-	#endif
-
 	matrix_init_user();
 }
 

--- a/keyboard/clueboard2/clueboard2.c
+++ b/keyboard/clueboard2/clueboard2.c
@@ -26,10 +26,6 @@ void matrix_init_kb(void) {
         init_backlight_pin();
     #endif
 
-    #ifdef RGBLIGHT_ENABLE
-        rgblight_init();
-    #endif
-
     // JTAG disable for PORT F. write JTD bit twice within four cycles.
     MCUCR |= (1<<JTD);
     MCUCR |= (1<<JTD);

--- a/keyboard/cluepad/cluepad.c
+++ b/keyboard/cluepad/cluepad.c
@@ -21,10 +21,6 @@ void matrix_init_kb(void) {
         init_backlight_pin();
     #endif
 
-    #ifdef RGBLIGHT_ENABLE
-        rgblight_init();
-    #endif
-
     // JTAG disable for PORT F. write JTD bit twice within four cycles.
     MCUCR |= (1<<JTD);
     MCUCR |= (1<<JTD);

--- a/keyboard/planck/planck.c
+++ b/keyboard/planck/planck.c
@@ -19,10 +19,6 @@ void matrix_init_kb(void) {
 	backlight_init_ports();
 #endif
 
-#ifdef RGBLIGHT_ENABLE
-	rgblight_init();
-#endif
-
 	// Turn status LED on
 	DDRE |= (1<<6);
 	PORTE |= (1<<6);
@@ -61,20 +57,20 @@ void backlight_init_ports()
     // Setup PB7 as output and output low.
     DDRB |= (1<<7);
     PORTB &= ~(1<<7);
-    
-    // Use full 16-bit resolution. 
+
+    // Use full 16-bit resolution.
     ICR1 = 0xFFFF;
 
     // I could write a wall of text here to explain... but TL;DW
     // Go read the ATmega32u4 datasheet.
     // And this: http://blog.saikoled.com/post/43165849837/secret-konami-cheat-code-to-high-resolution-pwm-on
-    
+
     // Pin PB7 = OCR1C (Timer 1, Channel C)
     // Compare Output Mode = Clear on compare match, Channel C = COM1C1=1 COM1C0=0
     // (i.e. start high, go low when counter matches.)
     // WGM Mode 14 (Fast PWM) = WGM13=1 WGM12=1 WGM11=1 WGM10=0
     // Clock Select = clk/1 (no prescaling) = CS12=0 CS11=0 CS10=1
-    
+
     TCCR1A = _BV(COM1C1) | _BV(WGM11); // = 0b00001010;
     TCCR1B = _BV(WGM13) | _BV(WGM12) | _BV(CS10); // = 0b00011001;
 
@@ -100,7 +96,7 @@ void backlight_set(uint8_t level)
         // Set the brightness
         CHANNEL = 0xFFFF;
     }
-    else        
+    else
     {
         // Turn on PWM control of PB7
         TCCR1A |= _BV(COM1C1);

--- a/keyboard/preonic/preonic.c
+++ b/keyboard/preonic/preonic.c
@@ -20,11 +20,6 @@ void matrix_init_kb(void) {
     	backlight_init_ports();
 	#endif
 
-	#ifdef RGBLIGHT_ENABLE
-		rgblight_init();
-	#endif
-
-
     // Turn status LED on
     DDRE |= (1<<6);
     PORTE |= (1<<6);
@@ -49,20 +44,20 @@ void backlight_init_ports()
     // Setup PB7 as output and output low.
     DDRB |= (1<<7);
     PORTB &= ~(1<<7);
-    
-    // Use full 16-bit resolution. 
+
+    // Use full 16-bit resolution.
     ICR1 = 0xFFFF;
 
     // I could write a wall of text here to explain... but TL;DW
     // Go read the ATmega32u4 datasheet.
     // And this: http://blog.saikoled.com/post/43165849837/secret-konami-cheat-code-to-high-resolution-pwm-on
-    
+
     // Pin PB7 = OCR1C (Timer 1, Channel C)
     // Compare Output Mode = Clear on compare match, Channel C = COM1C1=1 COM1C0=0
     // (i.e. start high, go low when counter matches.)
     // WGM Mode 14 (Fast PWM) = WGM13=1 WGM12=1 WGM11=1 WGM10=0
     // Clock Select = clk/1 (no prescaling) = CS12=0 CS11=0 CS10=1
-    
+
     TCCR1A = _BV(COM1C1) | _BV(WGM11); // = 0b00001010;
     TCCR1B = _BV(WGM13) | _BV(WGM12) | _BV(CS10); // = 0b00011001;
 
@@ -88,7 +83,7 @@ void backlight_set(uint8_t level)
         // Set the brightness
         CHANNEL = 0xFFFF;
     }
-    else        
+    else
     {
         // Prevent backlight blink on lowest level
         PORTB &= ~(_BV(PORTB7));

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -46,6 +46,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef ADB_MOUSE_ENABLE
 #   include "adb.h"
 #endif
+#ifdef RGBLIGHT_ENABLE
+#   include "rgblight.h"
+#endif
 
 #ifdef MATRIX_HAS_GHOST
 static bool is_row_ghosting(uint8_t row){
@@ -88,6 +91,9 @@ void keyboard_init(void) {
 #endif
 #ifdef BACKLIGHT_ENABLE
     backlight_init();
+#endif
+#ifdef RGBLIGHT_ENABLE
+    rgblight_init();
 #endif
 #if defined(NKRO_ENABLE) && defined(FORCE_NKRO)
 	keyboard_nkro = true;


### PR DESCRIPTION
- Stop users from having to manually add `rgblight_init`
