### PR TITLE
Makefile: Add QMK_VERSION & co to OPT_DEFS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,3 +113,8 @@ VPATH += $(QUANTUM_PATH)/audio
 include $(TMK_PATH)/protocol/lufa.mk
 include $(TMK_PATH)/common.mk
 include $(TMK_PATH)/rules.mk
+
+GIT_VERSION := $(shell git describe --abbrev=6 --dirty --always --tags 2>/dev/null || date +"%Y-%m-%d")
+
+OPT_DEFS += -DQMK_KEYBOARD=\"$(KEYBOARD)\" -DQMK_KEYMAP=\"$(KEYMAP)\"
+OPT_DEFS += -DQMK_VERSION=\"$(GIT_VERSION)\"


### PR DESCRIPTION
This adds the keyboard and keymap built, along with the QMK firmware's git hash (or a timestamp), to OPT_DEFS. That, in turn, allows keymaps to make use of these information, and do whatever they want with it. For example, one could print them on `LEADER v` like this:

```c
SEQ_ONE_KEY (KC_V) {
  SEND_STRING (QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION);
}
```

This addresses #366.