### PR TITLE
Fix the make all-keyboards command

### DIFF
--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -670,16 +670,33 @@ all-keyboards-defaults-%:
 all-keyboards-defaults: all-keyboards-defaults-all
 
 KEYBOARDS := $(SUBDIRS:$(TOP_DIR)/keyboard/%/=/keyboard/%)
-all-keyboards-%: $(KEYBOARDS)
-/keyboard/%:
-	$(eval KEYBOARD=$(patsubst /keyboard/%,%,$@))
-	$(eval KEYMAPS=$(notdir $(patsubst %/.,%,$(wildcard $(TOP_DIR)$@/keymaps/*/.))))
-	@for x in $(KEYMAPS) ; do \
-		printf "Compiling $(BOLD)$(KEYBOARD)$(NO_COLOR) with $(BOLD)$$x$(NO_COLOR)" | $(AWK) '{ printf "%-88s", $$0; }'; \
-		LOG=$$($(MAKE) -C $(TOP_DIR)$@ $(subst all-keyboards-,,$@) keymap=$$x VERBOSE=$(VERBOSE) COLOR=$(COLOR) SILENT=true 2>&1) ; if [ $$? -gt 0 ]; then $(PRINT_ERROR_PLAIN); elif [ "$$LOG" != "" ] ; then $(PRINT_WARNING_PLAIN); else $(PRINT_OK); fi; \
-	done
-
+all-keyboards-all: $(addsuffix -all,$(KEYBOARDS))
+all-keyboards-quick: $(addsuffix -quick,$(KEYBOARDS))
+all-keyboards-clean: $(addsuffix -clean,$(KEYBOARDS))
 all-keyboards: all-keyboards-all
+
+define make_keyboard
+$(eval KEYBOARD=$(patsubst /keyboard/%,%,$1))
+$(eval KEYMAPS=$(notdir $(patsubst %/.,%,$(wildcard $(TOP_DIR)$1/keymaps/*/.))))
+@for x in $(KEYMAPS) ; do \
+	printf "Compiling $(BOLD)$(KEYBOARD)$(NO_COLOR) with $(BOLD)$$x$(NO_COLOR)" | $(AWK) '{ printf "%-88s", $$0; }'; \
+	LOG=$$($(MAKE) -C $(TOP_DIR)$1 $2 keymap=$$x VERBOSE=$(VERBOSE) COLOR=$(COLOR) SILENT=true 2>&1) ; if [ $$? -gt 0 ]; then $(PRINT_ERROR_PLAIN); elif [ "$$LOG" != "" ] ; then $(PRINT_WARNING_PLAIN); else $(PRINT_OK); fi; \
+done
+endef
+
+define make_keyboard_helper
+# Just remove the -quick, -all and so on from the first argument and pass it forward
+$(call make_keyboard,$(subst -$2,,$1),$2)
+endef
+
+/keyboard/%-quick:
+	$(call make_keyboard_helper,$@,quick)
+/keyboard/%-all:
+	$(call make_keyboard_helper,$@,all)
+/keyboard/%-clean:
+	$(call make_keyboard_helper,$@,clean)
+/keyboard/%:
+	$(call make_keyboard_helper,$@,all)
 
 all-keymaps-%:
 	$(eval MAKECONFIG=$(call get_target,all-keymaps,$@))


### PR DESCRIPTION
Unfortunately the supported targets, like "quick", "all", "clean",and so on has to be repeated two extra times, but this is the best I can do with my makefile skills.