### PR TITLE
Change base box to avoid breakage in Arch box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,10 +5,10 @@ Vagrant.configure(2) do |config|
   # You can only have one config.vm.box uncommented at a time
 
   # Comment this and uncomment another if you don't want to use the minimal Arch box
-  config.vm.box = "dragon788/arch-ala-elasticdog"
+  #config.vm.box = "dragon788/arch-ala-elasticdog"
 
   # VMware/Virtualbox 64 bit
-  # config.vm.box = "phusion/ubuntu-14.04-amd64"
+  config.vm.box = "phusion/ubuntu-14.04-amd64"
   #
   # VMware/Virtualbox 64 bit
   #config.vm.box = "puphpet/centos65-x64"


### PR DESCRIPTION
I haven't had a chance to update the Arch base box in a while so using the Ubuntu one is far more likely to succeed for a new user (I did test that box recently as I traded my ErgoDox EZ to a friend and needed to reprogram it for him).

@ezuk @jackhumbert 