### PR TITLE
Long overdue fixes and improvements to environment setup scripts

### DIFF
--- a/util/1-setup-path-win.bat
+++ b/util/1-setup-path-win.bat
@@ -43,9 +43,14 @@ EXIT /b
 :: -----------------------------------------------------------------------------
 
 :KillExplorer
+ECHO.
+ECHO.
 ECHO Your desktop will be restarted. 
+ECHO.
 ECHO All file explorer windows except for the one you launched this script from WILL BE CLOSED.
+ECHO.
 ECHO Press enter when ready, or close this window if you would rather do a full restart of your computer at a later time.
+ECHO.
 PAUSE
 ping -n 5 127.0.0.1 > NUL 2>&1
 ECHO Killing process Explorer.exe. . . 

--- a/util/1-setup-path-win.bat
+++ b/util/1-setup-path-win.bat
@@ -2,11 +2,12 @@
 @ECHO OFF
 SET CMDLINERUNSTR=%SystemRoot%\system32\cmd.exe
 
+DEL script1.log > NUL 2>&1
 DEL add-paths.log > NUL 2>&1
 DEL add-paths-detail.log > NUL 2>&1
 DEL UPDATE > NUL 2>&1
 
-ELEVATE -wait add-paths.bat > NUL 2>&1
+ELEVATE -wait add-paths.bat >> script1.log 2>&1
 
 IF ERRORLEVEL 1 (
 	ECHO You denied admin access. Rerun the script, and be sure to press the yes button this time.

--- a/util/1-setup-path-win.bat
+++ b/util/1-setup-path-win.bat
@@ -2,12 +2,11 @@
 @ECHO OFF
 SET CMDLINERUNSTR=%SystemRoot%\system32\cmd.exe
 
-CD UTIL
 DEL add-paths.log > NUL 2>&1
 DEL add-paths-detail.log > NUL 2>&1
 DEL UPDATE > NUL 2>&1
 
-ELEVATE -wait %cd%\add-paths.bat > NUL 2>&1
+ELEVATE -wait add-paths.bat > NUL 2>&1
 
 IF ERRORLEVEL 1 (
 	ECHO You denied admin access. Rerun the script, and be sure to press the yes button this time.
@@ -57,5 +56,5 @@ ECHO Your desktop is now loading. . .
 ECHO.   
 ping -n 5 127.0.0.1 > NUL 2>&1
 START explorer.exe
-START explorer.exe %CD%\..
+START explorer.exe %CD%
 EXIT /b

--- a/util/2-setup-environment-win.bat
+++ b/util/2-setup-environment-win.bat
@@ -1,47 +1,55 @@
 @SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 @ECHO OFF
 
+CD %~dp0
+
 SET STARTINGDIR=%CD%
+echo %STARTINGDIR%
 
 :: Check for admin privilages
 SETX /M test test > nul 2>&1
 IF NOT ["%ERRORLEVEL%"]==["0"] (
 	ELEVATE -wait 2-setup-environment-win.bat & goto :EOF
-	ECHO FAILED. Rerun with administrator privileges.
-	GOTO ExitBatch
 ) 
+
+DEL %STARTINGDIR%\environment-setup.log
 
 :: Make sure path to MinGW exists - if so, CD to it
 SET MINGWPATH="C:\MinGW\bin"
-IF NOT EXIST !MINGWPATH! (ECHO "Path not found: %MINGWPATH%. Did you install MinGW to the default location?\n" && GOTO ExitBatch)
+IF NOT EXIST !MINGWPATH! (ECHO Path not found: %MINGWPATH%. Did you install MinGW to the default location? && GOTO ExitBatch)
 CD /D %MINGWPATH%
 
-
+ECHO.
 ECHO ------------------------------------------
 ECHO Installing wget and unzip
 ECHO ------------------------------------------
-mingw-get install msys-wget-bin msys-unzip-bin
+ECHO.
+mingw-get install msys-wget-bin msys-unzip-bin 
 
 MKDIR temp
 CD temp
 
+ECHO.
 ECHO ------------------------------------------
 ECHO Installing dfu-programmer.
 ECHO ------------------------------------------
-wget http://iweb.dl.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip
-unzip dfu-programmer-win-0.7.2.zip
-COPY dfu-programmer.exe ..
+ECHO.
+wget 'http://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-win-0.7.2.zip' >> %STARTINGDIR%\environment-setup.log
+unzip -o dfu-programmer-win-0.7.2.zip >> %STARTINGDIR%\environment-setup.log
+COPY dfu-programmer.exe .. >> %STARTINGDIR%\environment-setup.log
 
 ECHO ------------------------------------------
 ECHO Downloading driver
 ECHO ------------------------------------------
-wget http://iweb.dl.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip
-unzip libusb-win32-bin-1.2.6.0.zip
-COPY libusb-win32-bin-1.2.6.0\bin\x86\libusb0_x86.dll ../libusb0.dll
+wget http://downloads.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip >> %STARTINGDIR%\environment-setup.log
+unzip -o libusb-win32-bin-1.2.6.0.zip >> %STARTINGDIR%\environment-setup.log
+COPY libusb-win32-bin-1.2.6.0\bin\x86\libusb0_x86.dll ../libusb0.dll >> %STARTINGDIR%\environment-setup.log
 
+ECHO.
 ECHO ------------------------------------------
 ECHO Installing driver. Accept prompt.
 ECHO ------------------------------------------
+ECHO.
 IF EXIST "%WinDir%\System32\PnPUtil.exe" (%WinDir%\System32\PnPUtil.exe -i -a dfu-prog-usb-1.2.2\atmel_usb_dfu.inf && GOTO PNPUTILFOUND)
 IF EXIST "%WinDir%\Sysnative\PnPUtil.exe" (%WinDir%\Sysnative\PnPUtil.exe -i -a dfu-prog-usb-1.2.2\atmel_usb_dfu.inf && GOTO PNPUTILFOUND)
 

--- a/util/2-setup-environment-win.bat
+++ b/util/2-setup-environment-win.bat
@@ -13,7 +13,7 @@ IF NOT ["%ERRORLEVEL%"]==["0"] (
 
 :: Make sure path to MinGW exists - if so, CD to it
 SET MINGWPATH="C:\MinGW\bin"
-IF NOT EXIST !MINGWPATH! (ECHO Path not found: %MINGWPATH% && GOTO ExitBatch)
+IF NOT EXIST !MINGWPATH! (ECHO "Path not found: %MINGWPATH%. Did you install MinGW to the default location?\n" && GOTO ExitBatch)
 CD /D %MINGWPATH%
 
 

--- a/util/2-setup-environment-win.bat
+++ b/util/2-setup-environment-win.bat
@@ -6,6 +6,7 @@ SET STARTINGDIR=%CD%
 :: Check for admin privilages
 SETX /M test test > nul 2>&1
 IF NOT ["%ERRORLEVEL%"]==["0"] (
+	ELEVATE -wait 2-setup-environment-win.bat & goto :EOF
 	ECHO FAILED. Rerun with administrator privileges.
 	GOTO ExitBatch
 ) 


### PR DESCRIPTION
Most importantly, the SF download links should be working again, and they should be much less likely to need changing in the near future.

The second script also now supports being started as a non-administrator, and requesting to elevate its permissions.

The output is also a bit nicer.

I haven't tested this especially thoroughly, just on my Windows 10 machine. 