### PR TITLE
quantum: Add a tap dance feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ endif
 SRC += $(KEYBOARD_FILE) \
 	$(KEYMAP_FILE) \
 	$(QUANTUM_DIR)/quantum.c \
+	$(QUANTUM_DIR)/tap_dance.c \
 	$(QUANTUM_DIR)/keymap.c \
 	$(QUANTUM_DIR)/keycode_config.c
 
@@ -97,6 +98,10 @@ ifeq ($(strip $(RGBLIGHT_ENABLE)), yes)
 	SRC += $(QUANTUM_DIR)/light_ws2812.c
 	SRC += $(QUANTUM_DIR)/rgblight.c
 	OPT_DEFS += -DRGBLIGHT_ENABLE
+endif
+
+ifeq ($(strip $(TAP_DANCE_ENABLE)), yes)
+  OPT_DEFS += -DTAP_DANCE_ENABLE
 endif
 
 # Optimize size but this may cause error "relocation truncated to fit"

--- a/keyboards/alps64/matrix.c
+++ b/keyboards/alps64/matrix.c
@@ -100,6 +100,8 @@ uint8_t matrix_scan(void)
         }
     }
 
+    matrix_scan_tap_dance();
+
     return 1;
 }
 

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -187,7 +187,7 @@ uint8_t matrix_scan(void)
         }
     }
 
-
+    matrix_scan_tap_dance();
     matrix_scan_kb();
 
     return 1;

--- a/keyboards/hhkb/matrix.c
+++ b/keyboards/hhkb/matrix.c
@@ -150,6 +150,9 @@ uint8_t matrix_scan(void)
         KEY_POWER_OFF();
         suspend_power_down();
     }
+
+    matrix_scan_tap_dance();
+
     return 1;
 }
 

--- a/keyboards/sixkeyboard/matrix.c
+++ b/keyboards/sixkeyboard/matrix.c
@@ -87,6 +87,7 @@ uint8_t matrix_scan(void)
     matrix[0] = (PINC&(1<<7) ? 0 : (1<<0)) | (PINB&(1<<7) ? 0 : (1<<1)) | (PINB&(1<<5) ? 0 : (1<<2));
     matrix[1] = (PIND&(1<<6) ? 0 : (1<<0)) | (PIND&(1<<1) ? 0 : (1<<1)) | (PIND&(1<<4) ? 0 : (1<<2));
 
+    matrix_scan_tap_dance();
     matrix_scan_kb();
 
     return 1;

--- a/quantum/keymap.h
+++ b/quantum/keymap.h
@@ -77,6 +77,8 @@ enum quantum_keycodes {
 #endif
     QK_MOD_TAP            = 0x6000,
     QK_MOD_TAP_MAX        = 0x6FFF,
+    QK_TAP_DANCE          = 0x7100,
+    QK_TAP_DANCE_MAX      = 0x71FF,
 #ifdef UNICODE_ENABLE
     QK_UNICODE            = 0x8000,
     QK_UNICODE_MAX        = 0xFFFF,

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -136,6 +136,9 @@ bool process_record_quantum(keyrecord_t *record) {
     keycode = keymap_key_to_keycode(layer_switch_get_layer(key), key);
   #endif
 
+  if (!process_tap_dance(keycode, record))
+    return false;
+
   if (!process_record_kb(keycode, record))
     return false;
 
@@ -668,6 +671,7 @@ void matrix_scan_quantum() {
 
   #endif
 
+  matrix_scan_tap_dance();
   matrix_scan_kb();
 }
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -19,6 +19,7 @@
 #ifdef UNICODE_ENABLE
 	#include "unicode.h"
 #endif
+#include "tap_dance.h"
 
 #include "action_layer.h"
 #include "eeconfig.h"

--- a/quantum/tap_dance.c
+++ b/quantum/tap_dance.c
@@ -1,0 +1,104 @@
+#include "quantum.h"
+
+#if TAP_DANCE_ENABLE
+
+static qk_tap_dance_state_t qk_tap_dance_state;
+
+static void _process_tap_dance_action_pair (qk_tap_dance_state_t *state,
+                                            uint16_t kc1, uint16_t kc2) {
+  uint16_t kc;
+
+  if (state->count == 0)
+    return;
+
+  kc = (state->count == 1) ? kc1 : kc2;
+
+  register_code (kc);
+  unregister_code (kc);
+
+  if (state->count >= 2) {
+    reset_tap_dance (state);
+  }
+}
+
+static void _process_tap_dance_action_fn (qk_tap_dance_state_t *state,
+                                          qk_tap_dance_user_fn_t fn)
+{
+  fn(state);
+}
+
+void process_tap_dance_action (uint16_t keycode, keyrecord_t *record)
+{
+  uint16_t idx = keycode - QK_TAP_DANCE;
+  qk_tap_dance_action_t action;
+
+  action = tap_dance_actions[idx];
+
+  switch (action.type) {
+  case QK_TAP_DANCE_TYPE_PAIR:
+    _process_tap_dance_action_pair (&qk_tap_dance_state,
+                                    action.pair.kc1, action.pair.kc2);
+    break;
+  case QK_TAP_DANCE_TYPE_FN:
+    _process_tap_dance_action_fn (&qk_tap_dance_state, action.fn);
+    break;
+
+  default:
+    break;
+  }
+}
+
+bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
+  bool r = true;
+
+  switch(keycode) {
+  case QK_TAP_DANCE ... QK_TAP_DANCE_MAX:
+    if (qk_tap_dance_state.keycode && qk_tap_dance_state.keycode != keycode) {
+      process_tap_dance_action (keycode, record);
+    } else {
+      r = false;
+    }
+
+    if (record->event.pressed) {
+      qk_tap_dance_state.keycode = keycode;
+      qk_tap_dance_state.timer = timer_read ();
+      qk_tap_dance_state.count++;
+    }
+    break;
+
+  default:
+    if (qk_tap_dance_state.keycode) {
+      process_tap_dance_action (qk_tap_dance_state.keycode, NULL);
+
+      reset_tap_dance (&qk_tap_dance_state);
+    }
+    break;
+  }
+
+  return r;
+}
+
+void matrix_scan_tap_dance () {
+  if (qk_tap_dance_state.keycode && timer_elapsed (qk_tap_dance_state.timer) > TAPPING_TERM) {
+    process_tap_dance_action (qk_tap_dance_state.keycode, NULL);
+
+    reset_tap_dance (&qk_tap_dance_state);
+  }
+}
+
+void reset_tap_dance (qk_tap_dance_state_t *state) {
+  state->keycode = 0;
+  state->count = 0;
+}
+
+#else
+void matrix_scan_tap_dance () {
+}
+
+bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
+  return true;
+}
+
+void reset_tap_dance (qk_tap_dance_state_t *state) {
+}
+#endif

--- a/quantum/tap_dance.h
+++ b/quantum/tap_dance.h
@@ -1,0 +1,56 @@
+#ifndef TAP_DANCE_H
+#define TAP_DANCE_H
+
+#include <stdbool.h>
+#include <inttypes.h>
+
+typedef struct
+{
+  uint8_t count;
+  uint16_t keycode;
+  uint16_t timer;
+} qk_tap_dance_state_t;
+
+#define TD(n) (QK_TAP_DANCE + n)
+
+typedef enum
+{
+  QK_TAP_DANCE_TYPE_PAIR,
+  QK_TAP_DANCE_TYPE_FN,
+} qk_tap_dance_type_t;
+
+typedef void (*qk_tap_dance_user_fn_t) (qk_tap_dance_state_t *state);
+
+typedef struct
+{
+  qk_tap_dance_type_t type;
+  union {
+    struct {
+      uint16_t kc1;
+      uint16_t kc2;
+    } pair;
+    qk_tap_dance_user_fn_t fn;
+  };
+} qk_tap_dance_action_t;
+
+#define ACTION_TAP_DANCE_DOUBLE(kc1, kc2) { \
+    .type = QK_TAP_DANCE_TYPE_PAIR,         \
+    .pair = { kc1, kc2 }                    \
+  }
+
+#define ACTION_TAP_DANCE_FN(user_fn) { \
+    .type = QK_TAP_DANCE_TYPE_FN, \
+    .fn = user_fn                 \
+  }
+
+#if TAP_DANCE_ENABLE
+extern const qk_tap_dance_action_t tap_dance_actions[];
+#endif
+
+/* To be used internally */
+
+bool process_tap_dance(uint16_t keycode, keyrecord_t *record);
+void matrix_scan_tap_dance (void);
+void reset_tap_dance (qk_tap_dance_state_t *state);
+
+#endif


### PR DESCRIPTION
With this feature one can specify keys that behave differently, based on the amount of times they have been tapped, and when interrupted, they get handled before the interrupter.

To make it clear how this is different from `ACTION_FUNCTION_TAP`, lets explore a certain setup! We want one key to send `Space` on single tap, but `Enter` on double-tap.

With `ACTION_FUNCTION_TAP`, it is quite a rain-dance to set this up, and has the problem that when the sequence is interrupted, the interrupting key will be send first. Thus, `SPC a` will result in `a SPC` being sent, if they are typed within `TAPPING_TERM`. With the tap dance feature, that'll come out as `SPC a`, correctly.

The implementation hooks into two parts of the system, to achieve this: into `process_record_quantum()`, and the matrix scan. We need the latter to be able to time out a tap sequence even when a key is not being pressed, so `SPC` alone will time out and register after `TAPPING_TERM` time.

But lets start with how to use it, first!

First, you will need `TAP_DANCE_ENABLE=yes` in your `Makefile`, because the feature is disabled by default. This adds a little less than 1k to the firmware size. Next, you will want to define some tap-dance keys, which is easiest to do with the `TD()` macro, that - similar to `F()`, takes a number, which will later be used as an index into the `tap_dance_actions` array.

This array specifies what actions shall be taken when a tap-dance key is in action. Currently, there are two possible options:

* `ACTION_TAP_DANCE_DOUBLE(kc1, kc2)`: Sends the `kc1` keycode when tapped once, `kc2` otherwise.
* `ACTION_TAP_DANCE_FN(fn)`: Calls the specified function - defined in the user keymap - with the current state of the tap-dance action.

The first option is enough for a lot of cases, that just want dual roles. For example, `ACTION_TAP_DANCE(KC_SPC, KC_ENT)` will result in `Space` being sent on single-tap, `Enter` otherwise.

And that's the bulk of it!

Do note, however, that this implementation does have some consequences: keys do not register until either they reach the tapping ceiling, or they time out. This means that if you hold the key, nothing happens, no repeat, no nothing. It is possible to detect held state, and register an action then too, but that's not implemented yet. Keys also unregister immediately after being registered, so you can't even hold the second tap. This is intentional, to be consistent.

And now, on to the explanation of how it works!

The main entry point is `process_tap_dance()`, called from `process_record_quantum()`, which is run for every keypress, and our handler gets to run early. This function checks whether the key pressed is a tap-dance key. If it is not, and a tap-dance was in action, we handle that first, and enqueue the newly pressed key. If it is a tap-dance key, then we check if it is the same as the already active one (if there's one active, that is). If it is not, we fire off the old one first, then register the new one. If it was the same, we increment the counter and the timer.

This means that you have `TAPPING_TERM` time to tap the key again, you do not have to input all the taps within that timeframe. This allows for longer tap counts, with minimal impact on responsiveness.

Our next stop is `matrix_scan_tap_dance()`. This handles the timeout of tap-dance keys.

For the sake of flexibility, tap-dance actions can be either a pair of keycodes, or a user function. The latter allows one to handle higher tap counts, or do extra things, like blink the LEDs, fiddle with the backlighting, and so on. This is accomplished by using an union, and some clever macros.

In the end, lets see a full example!

```c
enum {
 CT_SE = 0,
 CT_CLN,
 CT_EGG
};

/* Have the above three on the keymap, TD(CT_SE), etc... */

void dance_cln (qk_tap_dance_state_t *state) {
  if (state->count == 1) {
    register_code (KC_RSFT);
    register_code (KC_SCLN);
    unregister_code (KC_SCLN);
    unregister_code (KC_RSFT);
  } else {
    register_code (KC_SCLN);
    unregister_code (KC_SCLN);
    reset_tap_dance (state);
  }
}

void dance_egg (qk_tap_dance_state_t *state) {
  if (state->count >= 100) {
    SEND_STRING ("Safety dance!");
    reset_tap_dance (state);
  }
}

const qk_tap_dance_action_t tap_dance_actions[] = {
  [CT_SE]  = ACTION_TAP_DANCE_DOUBLE (KC_SPC, KC_ENT)
 ,[CT_CLN] = ACTION_TAP_DANCE_FN (dance_cln)
 ,[CT_EGG] = ACTION_TAP_DANCE_FN (dance_egg)
};
```

This fixes #426.