### PR TITLE
Canceling Space Cadet state with opposite shift key

### DIFF
--- a/keyboards/kc60/Makefile
+++ b/keyboards/kc60/Makefile
@@ -57,7 +57,7 @@ BOOTMAGIC_ENABLE ?= no       # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE ?= yes       # Mouse keys(+4700)
 EXTRAKEY_ENABLE ?= yes       # Audio control and System control(+450)
 CONSOLE_ENABLE ?= yes        # Console for debug(+400)
-COMMAND_ENABLE ?= no         # Commands for debug and configuration
+COMMAND_ENABLE ?= yes        # Commands for debug and configuration
 KEYBOARD_LOCK_ENABLE ?= yes  # Allow locking of keyboard via magic key
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE ?= no       # Breathing sleep LED during USB suspend

--- a/keyboards/kc60/Makefile
+++ b/keyboards/kc60/Makefile
@@ -53,11 +53,11 @@ OPT_DEFS += -DBOOTLOADER_SIZE=4096
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE ?= yes      # Virtual DIP switch configuration(+1000)
+BOOTMAGIC_ENABLE ?= no       # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE ?= yes       # Mouse keys(+4700)
 EXTRAKEY_ENABLE ?= yes       # Audio control and System control(+450)
 CONSOLE_ENABLE ?= yes        # Console for debug(+400)
-COMMAND_ENABLE ?= yes        # Commands for debug and configuration
+COMMAND_ENABLE ?= no         # Commands for debug and configuration
 KEYBOARD_LOCK_ENABLE ?= yes  # Allow locking of keyboard via magic key
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE ?= no       # Breathing sleep LED during USB suspend

--- a/keyboards/kc60/config.h
+++ b/keyboards/kc60/config.h
@@ -107,12 +107,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
 )
 
-/* Prevent stuck modifiers when switching between FN layers */
-#define PREVENT_STUCK_MODIFIERS
-
-/* Enable opposite shift key to cancel space cadet state */
-#define DISABLE_SPACE_CADET_ROLLOVER
-
 /* control how magic key switches layers */
 //#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS  true
 //#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS  true

--- a/keyboards/kc60/config.h
+++ b/keyboards/kc60/config.h
@@ -107,6 +107,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
 )
 
+/* Prevent stuck modifiers when switching between FN layers */
+#define PREVENT_STUCK_MODIFIERS
+
+/* Enable opposite shift key to cancel space cadet state */
+#define DISABLE_SPACE_CADET_ROLLOVER
+
 /* control how magic key switches layers */
 //#define MAGIC_KEY_SWITCH_LAYER_WITH_FKEYS  true
 //#define MAGIC_KEY_SWITCH_LAYER_WITH_NKEYS  true

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -162,10 +162,12 @@ bool process_record_quantum(keyrecord_t *record) {
         register_mods(MOD_BIT(KC_LSFT));
       }
       else {
-        if (get_mods() & MOD_BIT(KC_RSFT)) {
-          shift_interrupted[0] = true;
-          shift_interrupted[1] = true;
-        }
+        #ifdef DISABLE_SPACE_CADET_ROLLOVER
+          if (get_mods() & MOD_BIT(KC_RSFT)) {
+            shift_interrupted[0] = true;
+            shift_interrupted[1] = true;
+          }
+        #endif
         if (!shift_interrupted[0]) {
           register_code(LSPO_KEY);
           unregister_code(LSPO_KEY);
@@ -182,10 +184,12 @@ bool process_record_quantum(keyrecord_t *record) {
         register_mods(MOD_BIT(KC_RSFT));
       }
       else {
-        if (get_mods() & MOD_BIT(KC_LSFT)) {
-          shift_interrupted[0] = true;
-          shift_interrupted[1] = true;
-        }
+        #ifdef DISABLE_SPACE_CADET_ROLLOVER
+          if (get_mods() & MOD_BIT(KC_LSFT)) {
+            shift_interrupted[0] = true;
+            shift_interrupted[1] = true;
+          }
+        #endif
         if (!shift_interrupted[1]) {
           register_code(RSPC_KEY);
           unregister_code(RSPC_KEY);

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -162,10 +162,10 @@ bool process_record_quantum(keyrecord_t *record) {
         register_mods(MOD_BIT(KC_LSFT));
       }
       else {
-		if (get_mods() & MOD_BIT(KC_RSFT)) {
-		  shift_interrupted[0] = true;
-		  shift_interrupted[1] = true;
-		}
+        if (get_mods() & MOD_BIT(KC_RSFT)) {
+          shift_interrupted[0] = true;
+          shift_interrupted[1] = true;
+        }
         if (!shift_interrupted[0]) {
           register_code(LSPO_KEY);
           unregister_code(LSPO_KEY);
@@ -182,10 +182,10 @@ bool process_record_quantum(keyrecord_t *record) {
         register_mods(MOD_BIT(KC_RSFT));
       }
       else {
-		if (get_mods() & MOD_BIT(KC_LSFT)) {
-		  shift_interrupted[0] = true;
-		  shift_interrupted[1] = true;
-		}
+        if (get_mods() & MOD_BIT(KC_LSFT)) {
+          shift_interrupted[0] = true;
+          shift_interrupted[1] = true;
+        }
         if (!shift_interrupted[1]) {
           register_code(RSPC_KEY);
           unregister_code(RSPC_KEY);

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -162,6 +162,10 @@ bool process_record_quantum(keyrecord_t *record) {
         register_mods(MOD_BIT(KC_LSFT));
       }
       else {
+		if (get_mods() & MOD_BIT(KC_RSFT)) {
+		  shift_interrupted[0] = true;
+		  shift_interrupted[1] = true;
+		}
         if (!shift_interrupted[0]) {
           register_code(LSPO_KEY);
           unregister_code(LSPO_KEY);
@@ -178,6 +182,10 @@ bool process_record_quantum(keyrecord_t *record) {
         register_mods(MOD_BIT(KC_RSFT));
       }
       else {
+		if (get_mods() & MOD_BIT(KC_LSFT)) {
+		  shift_interrupted[0] = true;
+		  shift_interrupted[1] = true;
+		}
         if (!shift_interrupted[1]) {
           register_code(RSPC_KEY);
           unregister_code(RSPC_KEY);

--- a/readme.md
+++ b/readme.md
@@ -309,6 +309,12 @@ It's defaulted to work on US keyboards, but if your layout uses different keys f
     #define LSPO_KEY KC_9
     #define RSPC_KEY KC_0
 
+You can also choose between different rollover behaviors of the shift keys by defining:
+
+    #define DISABLE_SPACE_CADET_ROLLOVER
+
+in your `config.h`. Disabling rollover allows you to use the opposite shift key to cancel the space cadet state in the event of an erroneous press instead of emitting a pair of parentheses when the keys are released.
+
 The only other thing you're going to want to do is create a `Makefile` in your keymap directory and set the following:
 
 ```


### PR DESCRIPTION
This change enables you to renege from outputting a character should you press a shift key erroneously when using the Space Cadet feature.

Current behavior:
Pressing LSHIFT + RSHIFT and then releasing the shift keys will cause you to emit a pair of parentheses corresponding to the order in which you released the shift keys.

New behavior:
Allows you to press RSHIFT to cancel the emission of a "(" when holding down LSHIFT. Alternatively, allows you to press LSHIFT to cancel the emission of a ")" when holding down RSHIFT. 