### PR TITLE
Integrate serial link support for ChibiOS and Infinity Ergodox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,8 +198,18 @@ ifeq ($(strip $(RGBLIGHT_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(TAP_DANCE_ENABLE)), yes)
-  OPT_DEFS += -DTAP_DANCE_ENABLE
+	OPT_DEFS += -DTAP_DANCE_ENABLE
 	SRC += $(QUANTUM_DIR)/process_keycode/process_tap_dance.c
+endif
+
+ifeq ($(strip $(SERIAL_LINK_ENABLE)), yes)
+	SERIAL_DIR = $(QUANTUM_DIR)/serial_link
+	SERIAL_PATH = $(QUANTUM_PATH)/serial_link
+	SERIAL_SRC = $(wildcard $(SERIAL_PATH)/protocol/*.c)
+	SERIAL_SRC += $(wildcard $(SERIAL_PATH)/system/*.c)
+	SRC += $(patsubst $(QUANTUM_PATH)/%,%,$(SERIAL_SRC))
+	OPT_DEFS += -DUSE_SERIAL_LINK
+	VAPTH += $(SERIAL_PATH)
 endif
 
 # Optimize size but this may cause error "relocation truncated to fit"

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,12 @@ ifndef KEYBOARD
 	KEYBOARD=planck
 endif
 
+MASTER ?= left
+ifdef master
+	MASTER = $(master)
+endif
+
+
 # converts things to keyboards/subproject
 ifneq (,$(findstring /,$(KEYBOARD)))
 	TEMP:=$(KEYBOARD)
@@ -210,6 +216,14 @@ ifeq ($(strip $(SERIAL_LINK_ENABLE)), yes)
 	SRC += $(patsubst $(QUANTUM_PATH)/%,%,$(SERIAL_SRC))
 	OPT_DEFS += -DSERIAL_LINK_ENABLE
 	VAPTH += $(SERIAL_PATH)
+endif
+
+ifeq ($(MASTER),right)	
+	OPT_DEFS += -DMASTER_IS_ON_RIGHT
+else 
+	ifneq ($(MASTER),left)
+$(error MASTER does not have a valid value(left/right))
+	endif
 endif
 
 # Optimize size but this may cause error "relocation truncated to fit"

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ ifeq ($(strip $(SERIAL_LINK_ENABLE)), yes)
 	SERIAL_SRC = $(wildcard $(SERIAL_PATH)/protocol/*.c)
 	SERIAL_SRC += $(wildcard $(SERIAL_PATH)/system/*.c)
 	SRC += $(patsubst $(QUANTUM_PATH)/%,%,$(SERIAL_SRC))
-	OPT_DEFS += -DUSE_SERIAL_LINK
+	OPT_DEFS += -DSERIAL_LINK_ENABLE
 	VAPTH += $(SERIAL_PATH)
 endif
 

--- a/keyboards/infinity_ergodox/Makefile
+++ b/keyboards/infinity_ergodox/Makefile
@@ -66,6 +66,7 @@ COMMAND_ENABLE ?= yes    # Commands for debug and configuration
 SLEEP_LED_ENABLE ?= yes  # Breathing sleep LED during USB suspend
 NKRO_ENABLE ?= yes	    # USB Nkey Rollover
 CUSTOM_MATRIX ?= yes # Custom matrix file
+SERIAL_LINK_ENABLE = yes
 
 ifndef QUANTUM_DIR
 	include ../../Makefile

--- a/keyboards/infinity_ergodox/infinity_ergodox.c
+++ b/keyboards/infinity_ergodox/infinity_ergodox.c
@@ -1,1 +1,11 @@
 #include "infinity_ergodox.h"
+#include "ch.h"
+#include "hal.h"
+#include "serial_link/system/serial_link.h"
+
+void init_serial_link_hal(void) {
+    PORTA->PCR[1] = PORTx_PCRn_PE | PORTx_PCRn_PS | PORTx_PCRn_PFE | PORTx_PCRn_MUX(2);
+    PORTA->PCR[2] = PORTx_PCRn_DSE | PORTx_PCRn_SRE | PORTx_PCRn_MUX(2);
+    PORTE->PCR[0] = PORTx_PCRn_PE | PORTx_PCRn_PS | PORTx_PCRn_PFE | PORTx_PCRn_MUX(3);
+    PORTE->PCR[1] = PORTx_PCRn_DSE | PORTx_PCRn_SRE | PORTx_PCRn_MUX(3);
+}

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -97,6 +97,15 @@ ifeq ($(strip $(KEYMAP_SECTION_ENABLE)), yes)
     endif
 endif
 
+ifeq ($(MASTER),right)	
+	OPT_DEFS += -DMASTER_IS_ON_RIGHT
+else 
+	ifneq ($(MASTER),left)
+$(error MASTER does not have a valid value(left/right))
+	endif
+endif
+
+
 # Version string
 OPT_DEFS += -DVERSION=$(shell (git describe --always --dirty || echo 'unknown') 2> /dev/null)
 

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -49,6 +49,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RGBLIGHT_ENABLE
 #   include "rgblight.h"
 #endif
+#ifdef SERIAL_LINK_ENABLE
+#   include "serial_link/system/serial_link.h"
+#endif
 
 #ifdef MATRIX_HAS_GHOST
 static bool has_ghost_in_row(uint8_t row)
@@ -167,11 +170,15 @@ MATRIX_LOOP_END:
 #endif
 
 #ifdef SERIAL_MOUSE_ENABLE
-        serial_mouse_task();
+    serial_mouse_task();
 #endif
 
 #ifdef ADB_MOUSE_ENABLE
-        adb_mouse_task();
+    adb_mouse_task();
+#endif
+
+#ifdef SERIAL_LINK_ENABLE
+	serial_link_update();
 #endif
 
     // update LED

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -35,6 +35,9 @@
 #ifdef SLEEP_LED_ENABLE
 #include "sleep_led.h"
 #endif
+#ifdef SERIAL_LINK_ENABLE
+#include "serial_link/system/serial_link.h"
+#endif
 #include "suspend.h"
 
 
@@ -98,9 +101,27 @@ int main(void) {
   /* init printf */
   init_printf(NULL,sendchar_pf);
 
-  /* Wait until the USB is active */
-  while(USB_DRIVER.state != USB_ACTIVE)
+#ifdef SERIAL_LINK_ENABLE
+  init_serial_link();
+#endif
+
+  host_driver_t* driver = NULL;
+
+  /* Wait until the USB or serial link is active */
+  while (true) {
+    if(USB_DRIVER.state == USB_ACTIVE) {
+      driver = &chibios_driver;
+      break;
+    }
+#ifdef SERIAL_LINK_ENABLE
+    if(is_serial_link_connected()) {
+      driver = get_serial_link_driver();
+      break;
+    }
+    serial_link_update();
+#endif
     chThdSleepMilliseconds(50);
+  }
 
   /* Do need to wait here!
    * Otherwise the next print might start a transfer on console EP
@@ -113,7 +134,7 @@ int main(void) {
 
   /* init TMK modules */
   keyboard_init();
-  host_set_driver(&chibios_driver);
+  host_set_driver(driver);
 
 #ifdef SLEEP_LED_ENABLE
   sleep_led_init();
@@ -128,6 +149,9 @@ int main(void) {
       print("[s]");
       while(USB_DRIVER.state == USB_SUSPENDED) {
         /* Do this in the suspended state */
+#ifdef SERIAL_LINK_ENABLE
+        serial_link_update();
+#endif
         suspend_power_down(); // on AVR this deep sleeps for 15ms
         /* Remote wakeup */
         if((USB_DRIVER.status & 2) && suspend_wakeup_condition()) {


### PR DESCRIPTION
This enables the serial link support for ChibiOS and Infinity Ergodox.

So with this pull request both of the Infinity Ergodox halves work correctly. This should be added to the documentation once it's written, but by default the left hand connects to the computer, but it's possible to override that by specifying master=right either through the commandline or make files