### PR TITLE
Some fixes for keycode processing

### DIFF
--- a/keyboards/chibios_test/keymaps/default/keymap.c
+++ b/keyboards/chibios_test/keymaps/default/keymap.c
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "chibios_test.h"
 
 const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    {{KC_CAPS}}, // test with KC_CAPS, KC_A, KC_BTLD
+    {{KC_CAPS}}, // test with KC_CAPS, KC_A, RESET
 };
 
 const uint16_t fn_actions[] = {

--- a/keyboards/infinity_ergodox/keymaps/default/keymap.c
+++ b/keyboards/infinity_ergodox/keymaps/default/keymap.c
@@ -18,6 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "infinity_ergodox.h"
 
+// Workaround for old keymap format
+#define KC_RESET RESET
+
 const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KEYMAP(  // layer 0 : default
         // left hand
@@ -63,7 +66,7 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     KEYMAP(  // layer 2 : keyboard functions
         // left hand
-        BTLD,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
+        RESET,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
         TRNS,TRNS,TRNS,TRNS,TRNS,TRNS, FN3,
         TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
         TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -62,7 +62,7 @@ action_t action_for_key(uint8_t layer, keypos_t key)
         case KC_SYSTEM_POWER ... KC_SYSTEM_WAKE:
             action.code = ACTION_USAGE_SYSTEM(KEYCODE2SYSTEM(keycode));
             break;
-        case KC_AUDIO_MUTE ... KC_WWW_FAVORITES:
+        case KC_AUDIO_MUTE ... KC_MEDIA_REWIND:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
         case KC_MS_UP ... KC_MS_ACCEL2:

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -31,7 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define IS_SPECIAL(code)         ((0xA5 <= (code) && (code) <= 0xDF) || (0xE8 <= (code) && (code) <= 0xFF))
 #define IS_SYSTEM(code)          (KC_PWR       <= (code) && (code) <= KC_WAKE)
-#define IS_CONSUMER(code)        (KC_MUTE      <= (code) && (code) <= KC_WFAV)
+#define IS_CONSUMER(code)        (KC_MUTE      <= (code) && (code) <= KC_MRWD)
 #define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN31)
 #define IS_MOUSEKEY(code)        (KC_MS_UP     <= (code) && (code) <= KC_MS_ACCEL2)
 #define IS_MOUSEKEY_MOVE(code)   (KC_MS_UP     <= (code) && (code) <= KC_MS_RIGHT)

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -156,8 +156,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_WSTP KC_WWW_STOP
 #define KC_WREF KC_WWW_REFRESH
 #define KC_WFAV KC_WWW_FAVORITES
-/* Jump to bootloader */
-#define KC_BTLD KC_BOOTLOADER
 /* Transparent */
 #define KC_TRANSPARENT  1
 #define KC_TRNS KC_TRANSPARENT
@@ -427,9 +425,6 @@ enum internal_special_keycodes {
     KC_WWW_FAVORITES,
     KC_MEDIA_FAST_FORWARD,
     KC_MEDIA_REWIND,    /* 0xBC */
-
-    /* Jump to bootloader */
-    KC_BOOTLOADER       = 0xBF,
 
     /* Fn key */
     KC_FN0              = 0xC0,


### PR DESCRIPTION
See the individual commit descriptions for more information

Originally I noticed that KC_BTLDR keycode didn't work so I started investigating. After I found out that it had been replaced by RESET in QMK, I found a couple of other issues that I fixed as well. 

I'm quite sure that the other fixes are correct, but not 100% sure. So it's good if you review the changes carefully as well. If needed I can remove some of the fixes.