### PR TITLE
Create keycodes for RGB control functions

### DIFF
--- a/keyboards/clueboard/keymaps/default/keymap.c
+++ b/keyboards/clueboard/keymaps/default/keymap.c
@@ -67,11 +67,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
 [_RS] = KEYMAP(
   #ifdef RGBLIGHT_ENABLE
-  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, F(1),             F(7), \
-  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,RESET,  KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                   F(8), \
+  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, RGB_TOG,             RGB_VAI, \
+  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,RESET,  KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                   RGB_VAD, \
   KC_TRNS, KC_TRNS, MO(_RS),KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                         \
-  MO(_FL), KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  MO(_FL),          F(5),          \
-  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,        F(2),   F(2),                            KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, F(4),    F(6),    F(3)),
+  MO(_FL), KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  MO(_FL),          RGB_SAI,          \
+  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,        RGB_MOD,   RGB_MOD,                            KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, RGB_HUD,    RGB_SAD,    RGB_HUI),
   #else
   KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS,          KC_TRNS, \
   KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,RESET,  KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                   KC_TRNS, \
@@ -83,30 +83,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 enum function_id {
     SHIFT_ESC,
-    #ifdef RGBLIGHT_ENABLE
-    RGBLED_TOGGLE,
-    RGBLED_STEP_MODE,
-    RGBLED_INCREASE_HUE,
-    RGBLED_DECREASE_HUE,
-    RGBLED_INCREASE_SAT,
-    RGBLED_DECREASE_SAT,
-    RGBLED_INCREASE_VAL,
-    RGBLED_DECREASE_VAL
-    #endif
 };
 
 const uint16_t PROGMEM fn_actions[] = {
   [0]  = ACTION_FUNCTION(SHIFT_ESC),
-  #ifdef RGBLIGHT_ENABLE
-  [1]  = ACTION_FUNCTION(RGBLED_TOGGLE),
-  [2]  = ACTION_FUNCTION(RGBLED_STEP_MODE),
-  [3]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
-  [4]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
-  [5]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
-  [6]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
-  [7]  = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
-  [8]  = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
-  #endif
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
@@ -132,49 +112,5 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
         }
       }
       break;
-    //led operations
-    #ifdef RGBLIGHT_ENABLE
-    case RGBLED_TOGGLE:
-      if (record->event.pressed) {
-        rgblight_toggle();
-      }
-
-      break;
-    case RGBLED_INCREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_increase_hue();
-      }
-      break;
-    case RGBLED_DECREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_decrease_hue();
-      }
-      break;
-    case RGBLED_INCREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_increase_sat();
-      }
-      break;
-    case RGBLED_DECREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_decrease_sat();
-      }
-      break;
-    case RGBLED_INCREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_increase_val();
-      }
-      break;
-    case RGBLED_DECREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_decrease_val();
-      }
-      break;
-    case RGBLED_STEP_MODE:
-      if (record->event.pressed) {
-        rgblight_step();
-      }
-      break;
-    #endif
   }
 }

--- a/keyboards/clueboard/keymaps/max/keymap.c
+++ b/keyboards/clueboard/keymaps/max/keymap.c
@@ -66,78 +66,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * `----------------------------------------------------------------------------------'
    */
 [_RS] = KEYMAP(
-  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, F(0),             F(6), \
-  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,RESET,  KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                   F(7), \
+  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, RGB_TOG,             RGB_VAI, \
+  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,RESET,  KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                   RGB_VAD, \
   KC_TRNS, KC_TRNS, MO(_RS),KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,                         \
-  MO(_FL), KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  MO(_FL),          F(4),          \
-  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,        F(1),   F(1),                            KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, F(3),    F(5),    F(2)),
+  MO(_FL), KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  MO(_FL),          RGB_SAI,          \
+  KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,        RGB_MOD,   RGB_MOD,                            KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, RGB_HUD,    RGB_SAD,    RGB_HUI),
 };
 
 enum function_id {
-    RGBLED_TOGGLE,
-    RGBLED_STEP_MODE,
-    RGBLED_INCREASE_HUE,
-    RGBLED_DECREASE_HUE,
-    RGBLED_INCREASE_SAT,
-    RGBLED_DECREASE_SAT,
-    RGBLED_INCREASE_VAL,
-    RGBLED_DECREASE_VAL,
 };
 
 const uint16_t PROGMEM fn_actions[] = {
-  [0]  = ACTION_FUNCTION(RGBLED_TOGGLE),
-  [1]  = ACTION_FUNCTION(RGBLED_STEP_MODE),
-  [2]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
-  [3]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
-  [4]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
-  [5]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
-  [6]  = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
-  [7]  = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
   switch (id) {
-    case RGBLED_TOGGLE:
-      //led operations
-      if (record->event.pressed) {
-        rgblight_toggle();
-      }
-
-      break;
-    case RGBLED_INCREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_increase_hue();
-      }
-      break;
-    case RGBLED_DECREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_decrease_hue();
-      }
-      break;
-    case RGBLED_INCREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_increase_sat();
-      }
-      break;
-    case RGBLED_DECREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_decrease_sat();
-      }
-      break;
-    case RGBLED_INCREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_increase_val();
-      }
-      break;
-    case RGBLED_DECREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_decrease_val();
-      }
-      break;
-    case RGBLED_STEP_MODE:
-      if (record->event.pressed) {
-        rgblight_step();
-      }
-      break;
   }
 }

--- a/keyboards/clueboard/keymaps/max/keymap.c
+++ b/keyboards/clueboard/keymaps/max/keymap.c
@@ -73,8 +73,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,        RGB_MOD,   RGB_MOD,                            KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, RGB_HUD,    RGB_SAD,    RGB_HUI),
 };
 
-enum function_id {
-};
+/*enum function_id {
+};*/
 
 const uint16_t PROGMEM fn_actions[] = {
 };

--- a/keyboards/cluepad/keymaps/default/keymap.c
+++ b/keyboards/cluepad/keymaps/default/keymap.c
@@ -52,8 +52,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   RGB_MOD,                      KC_TRNS)
 };
 
-enum function_id {
-};
+/*enum function_id {
+};*/
 
 const uint16_t PROGMEM fn_actions[] = {
 };

--- a/keyboards/cluepad/keymaps/default/keymap.c
+++ b/keyboards/cluepad/keymaps/default/keymap.c
@@ -1,7 +1,6 @@
 #include "cluepad.h"
 
 #include "backlight.h"
-#include "rgblight.h"
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
@@ -46,77 +45,21 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    * '-------------------'
    */
 [_FL] = KEYMAP(
-  LT(_FL, KC_NLCK), KC_TRNS, KC_TRNS, F(0), \
-  KC_TRNS,          F(4),    KC_TRNS, F(6), \
-  F(3),             BL_STEP, F(2), \
-  KC_TRNS,          F(5),    KC_TRNS, F(7), \
-  F(1),                      KC_TRNS)
+  LT(_FL, KC_NLCK), KC_TRNS, KC_TRNS, RGB_TOG, \
+  KC_TRNS,          RGB_SAI,    KC_TRNS, RGB_VAI, \
+  RGB_HUD,             BL_STEP, RGB_HUI, \
+  KC_TRNS,          RGB_SAD,    KC_TRNS, RGB_VAD, \
+  RGB_MOD,                      KC_TRNS)
 };
 
 enum function_id {
-    RGBLED_TOGGLE,
-    RGBLED_STEP_MODE,
-    RGBLED_INCREASE_HUE,
-    RGBLED_DECREASE_HUE,
-    RGBLED_INCREASE_SAT,
-    RGBLED_DECREASE_SAT,
-    RGBLED_INCREASE_VAL,
-    RGBLED_DECREASE_VAL,
 };
 
 const uint16_t PROGMEM fn_actions[] = {
-  [0]  = ACTION_FUNCTION(RGBLED_TOGGLE),
-  [1]  = ACTION_FUNCTION(RGBLED_STEP_MODE),
-  [2]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
-  [3]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
-  [4]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
-  [5]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
-  [6]  = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
-  [7]  = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
   switch (id) {
-    case RGBLED_TOGGLE:
-      if (record->event.pressed) {
-        rgblight_toggle();
-      }
-      break;
-    case RGBLED_INCREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_increase_hue();
-      }
-      break;
-    case RGBLED_DECREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_decrease_hue();
-      }
-      break;
-    case RGBLED_INCREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_increase_sat();
-      }
-      break;
-    case RGBLED_DECREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_decrease_sat();
-      }
-      break;
-    case RGBLED_INCREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_increase_val();
-      }
-      break;
-    case RGBLED_DECREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_decrease_val();
-      }
-      break;
-    case RGBLED_STEP_MODE:
-      if (record->event.pressed) {
-        rgblight_step();
-      }
-      break;
   }
 }
 

--- a/keyboards/kc60/keymaps/stanleylai/keymap.c
+++ b/keyboards/kc60/keymaps/stanleylai/keymap.c
@@ -38,7 +38,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   RESET,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,    KC_NO,    KC_NO, \
   KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,    KC_NO,    KC_NO, \
   KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,    KC_NO,    KC_NO,  \
-  KC_TRNS,KC_NO,  F(1),   F(2),   F(3),   F(4),   F(5),   F(6),   F(7),   F(8),   BL_STEP,BL_TOGG,  KC_TRNS,  KC_TRNS,\
+  KC_TRNS,KC_NO,  RGB_TOG,RGB_MOD,RGB_HUI,RGB_HUD,RGB_SAI,RGB_SAD,RGB_VAI,RGB_VAD,BL_STEP,BL_TOGG,  KC_TRNS,  KC_TRNS,\
   KC_TRNS,KC_TRNS,KC_TRNS,                KC_TRNS,                                KC_TRNS,KC_TRNS,  KC_TRNS,  KC_TRNS),
   #else
   RESET,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,    KC_NO,    KC_NO, \
@@ -52,30 +52,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 enum function_id {
     SHIFT_ESC,
-    #ifdef RGBLIGHT_ENABLE
-    RGBLED_TOGGLE,
-    RGBLED_STEP_MODE,
-    RGBLED_INCREASE_HUE,
-    RGBLED_DECREASE_HUE,
-    RGBLED_INCREASE_SAT,
-    RGBLED_DECREASE_SAT,
-    RGBLED_INCREASE_VAL,
-    RGBLED_DECREASE_VAL,
-    #endif
 };
 
 const uint16_t PROGMEM fn_actions[] = {
   [0]  = ACTION_FUNCTION(SHIFT_ESC),
-  #ifdef RGBLIGHT_ENABLE
-  [1]  = ACTION_FUNCTION(RGBLED_TOGGLE),
-  [2]  = ACTION_FUNCTION(RGBLED_STEP_MODE),
-  [3]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
-  [4]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
-  [5]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
-  [6]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
-  [7]  = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
-  [8]  = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
-  #endif
 };
 
 #define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
@@ -102,50 +82,5 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
         }
       }
       break;
-
-    #ifdef RGBLIGHT_ENABLE
-
-    case RGBLED_TOGGLE:
-      //led operations
-      if (record->event.pressed) {
-        rgblight_toggle();
-      }
-      break;
-    case RGBLED_INCREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_increase_hue();
-      }
-      break;
-    case RGBLED_DECREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_decrease_hue();
-      }
-      break;
-    case RGBLED_INCREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_increase_sat();
-      }
-      break;
-    case RGBLED_DECREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_decrease_sat();
-      }
-      break;
-      case RGBLED_INCREASE_VAL:
-        if (record->event.pressed) {
-          rgblight_increase_val();
-        }
-        break;
-      case RGBLED_DECREASE_VAL:
-        if (record->event.pressed) {
-          rgblight_decrease_val();
-        }
-        break;
-      case RGBLED_STEP_MODE:
-        if (record->event.pressed) {
-          rgblight_step();
-        }
-        break;
-      #endif
   }
 }

--- a/keyboards/kc60/keymaps/ws2812/keymap.c
+++ b/keyboards/kc60/keymaps/ws2812/keymap.c
@@ -52,7 +52,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  \
   KC_TRNS, KC_TRNS, KC_UP,   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, BL_DEC,  BL_INC,  BL_TOGG, \
   KC_TRNS, KC_LEFT, KC_DOWN, KC_RGHT, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
-  KC_TRNS, KC_TRNS, F(1),    F(2),    F(3),    F(4),    F(5),    F(6),    F(7),    F(8),    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
+  KC_TRNS, KC_TRNS, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                                     KC_TRNS, KC_TRNS, KC_TRNS, RESET),
   #else
   KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  \
@@ -65,30 +65,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 enum function_id {
     SHIFT_ESC,
-    #ifdef RGBLIGHT_ENABLE
-    RGBLED_TOGGLE,
-    RGBLED_STEP_MODE,
-    RGBLED_INCREASE_HUE,
-    RGBLED_DECREASE_HUE,
-    RGBLED_INCREASE_SAT,
-    RGBLED_DECREASE_SAT,
-    RGBLED_INCREASE_VAL,
-    RGBLED_DECREASE_VAL
-    #endif
 };
 
 const uint16_t PROGMEM fn_actions[] = {
   [0]  = ACTION_FUNCTION(SHIFT_ESC),
-  #ifdef RGBLIGHT_ENABLE
-  [1]  = ACTION_FUNCTION(RGBLED_TOGGLE),
-  [2]  = ACTION_FUNCTION(RGBLED_STEP_MODE),
-  [3]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
-  [4]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
-  [5]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
-  [6]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
-  [7]  = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
-  [8]  = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
-  #endif
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
@@ -114,48 +94,5 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
         }
       }
       break;
-    //led operations
-    #ifdef RGBLIGHT_ENABLE
-    case RGBLED_TOGGLE:
-      if (record->event.pressed) {
-        rgblight_toggle();
-      }
-      break;
-    case RGBLED_INCREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_increase_hue();
-      }
-      break;
-    case RGBLED_DECREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_decrease_hue();
-      }
-      break;
-    case RGBLED_INCREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_increase_sat();
-      }
-      break;
-    case RGBLED_DECREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_decrease_sat();
-      }
-      break;
-    case RGBLED_INCREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_increase_val();
-      }
-      break;
-    case RGBLED_DECREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_decrease_val();
-      }
-      break;
-    case RGBLED_STEP_MODE:
-      if (record->event.pressed) {
-        rgblight_step();
-      }
-      break;
-    #endif
   }
 }

--- a/keyboards/phantom/keymaps/default/keymap.c
+++ b/keyboards/phantom/keymaps/default/keymap.c
@@ -1,9 +1,5 @@
 #include "phantom.h"
 
-#ifdef RGBLIGHT_ENABLE
-#include "rgblight.h"
-#endif
-
 // Used for SHIFT_ESC
 #define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
 
@@ -59,7 +55,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, RESET, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,   KC_TRNS,  KC_TRNS, KC_UP, KC_TRNS, \
-  KC_TRNS,  F(1), F(2), F(3), F(4), F(5), F(6), F(7), F(8), KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
+  KC_TRNS,  RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
   #else
   KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, \
@@ -73,30 +69,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 enum function_id {
     SHIFT_ESC,
-    #ifdef RGBLIGHT_ENABLE
-    RGBLED_TOGGLE,
-    RGBLED_STEP_MODE,
-    RGBLED_INCREASE_HUE,
-    RGBLED_DECREASE_HUE,
-    RGBLED_INCREASE_SAT,
-    RGBLED_DECREASE_SAT,
-    RGBLED_INCREASE_VAL,
-    RGBLED_DECREASE_VAL
-    #endif
 };
 
 const uint16_t PROGMEM fn_actions[] = {
   [0]  = ACTION_FUNCTION(SHIFT_ESC),
-  #ifdef RGBLIGHT_ENABLE
-  [1]  = ACTION_FUNCTION(RGBLED_TOGGLE),
-  [2]  = ACTION_FUNCTION(RGBLED_STEP_MODE),
-  [3]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
-  [4]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
-  [5]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
-  [6]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
-  [7]  = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
-  [8]  = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
-  #endif
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
@@ -122,48 +98,5 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
         }
       }
       break;
-    //led operations
-    #ifdef RGBLIGHT_ENABLE
-    case RGBLED_TOGGLE:
-      if (record->event.pressed) {
-        rgblight_toggle();
-      }
-      break;
-    case RGBLED_INCREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_increase_hue();
-      }
-      break;
-    case RGBLED_DECREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_decrease_hue();
-      }
-      break;
-    case RGBLED_INCREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_increase_sat();
-      }
-      break;
-    case RGBLED_DECREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_decrease_sat();
-      }
-      break;
-    case RGBLED_INCREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_increase_val();
-      }
-      break;
-    case RGBLED_DECREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_decrease_val();
-      }
-      break;
-    case RGBLED_STEP_MODE:
-      if (record->event.pressed) {
-        rgblight_step();
-      }
-      break;
-    #endif
   }
 }

--- a/keyboards/phantom/led.c
+++ b/keyboards/phantom/led.c
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "stdint.h"
 #include "led.h"
 
-void led_init(void) {
+void led_init_ports(void) {
     // * Set our LED pins as output
     DDRB |= (1<<6);
 	DDRB |= (1<<7);

--- a/keyboards/planck/keymaps/yang/keymap.c
+++ b/keyboards/planck/keymaps/yang/keymap.c
@@ -57,9 +57,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 }
 };
 
-enum function_id {
-    
-};
+/*enum function_id {
+  
+};*/
 
 const uint16_t PROGMEM fn_actions[] = {
   [0]  = ACTION_LAYER_TAP_KEY(_RGB, KC_SPC),

--- a/keyboards/planck/keymaps/yang/keymap.c
+++ b/keyboards/planck/keymaps/yang/keymap.c
@@ -51,33 +51,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_RGB] = { /* RGBLIGHT */
   {KC_TRNS,  KC_PGUP,  KC_UP,    KC_PGDN,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_DEL},
   {KC_TRNS,  KC_LEFT,  KC_DOWN,  KC_RGHT,  KC_TRNS,  KC_HOME,  KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  KC_END,   KC_TRNS},
-  {KC_TRNS,  F(1),     F(2),     F(3),     F(4),     F(5),     F(6),     F(7),     F(8),     KC_TRNS,  KC_TRNS,  KC_TRNS},
+  {KC_TRNS,  RGB_TOG,  RGB_MOD,  RGB_HUI,  RGB_HUD,  RGB_SAI,  RGB_SAD,  RGB_VAI,  RGB_VAD,  KC_TRNS,  KC_TRNS,  KC_TRNS},
   {KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS}
 
 }
 };
 
 enum function_id {
-    RGBLED_TOGGLE,
-    RGBLED_STEP_MODE,
-    RGBLED_INCREASE_HUE,
-    RGBLED_DECREASE_HUE,
-    RGBLED_INCREASE_SAT,
-    RGBLED_DECREASE_SAT,
-    RGBLED_INCREASE_VAL,
-    RGBLED_DECREASE_VAL,
+    
 };
 
 const uint16_t PROGMEM fn_actions[] = {
   [0]  = ACTION_LAYER_TAP_KEY(_RGB, KC_SPC),
-  [1]  = ACTION_FUNCTION(RGBLED_TOGGLE),
-  [2]  = ACTION_FUNCTION(RGBLED_STEP_MODE),
-  [3]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
-  [4]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
-  [5]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
-  [6]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
-  [7]  = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
-  [8]  = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
 };
 
 const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
@@ -100,47 +85,6 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
   switch (id) {
-    case RGBLED_TOGGLE:
-      //led operations
-      if (record->event.pressed) {
-        rgblight_toggle();
-      }
-
-      break;
-    case RGBLED_INCREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_increase_hue();
-      }
-      break;
-    case RGBLED_DECREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_decrease_hue();
-      }
-      break;
-    case RGBLED_INCREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_increase_sat();
-      }
-      break;
-    case RGBLED_DECREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_decrease_sat();
-      }
-      break;
-      case RGBLED_INCREASE_VAL:
-        if (record->event.pressed) {
-          rgblight_increase_val();
-        }
-        break;
-      case RGBLED_DECREASE_VAL:
-        if (record->event.pressed) {
-          rgblight_decrease_val();
-        }
-        break;
-      case RGBLED_STEP_MODE:
-        if (record->event.pressed) {
-          rgblight_step();
-        }
-        break;
+  
   }
 }

--- a/keyboards/satan/keymaps/default/keymap.c
+++ b/keyboards/satan/keymaps/default/keymap.c
@@ -1,8 +1,5 @@
 #include "satan.h"
 
-#ifdef RGBLIGHT_ENABLE
-#include "rgblight.h"
-#endif
 
 // Used for SHIFT_ESC
 #define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
@@ -53,7 +50,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_GRV, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RESET,  \
   KC_TRNS,KC_TRNS,KC_TRNS,  KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS,   KC_TRNS,   BL_DEC,   BL_INC,   BL_TOGG, \
   KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS, KC_TRNS,    KC_TRNS,              KC_TRNS, \
-  KC_TRNS, F(1), F(2), F(3), F(4), F(5), F(6), F(7), F(8), KC_TRNS, KC_TRNS, KC_TRNS, \
+  KC_TRNS,RGB_TOG,RGB_MOD,RGB_HUI,RGB_HUD,RGB_SAI,RGB_SAD,RGB_VAI,RGB_VAD, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS,KC_TRNS,KC_TRNS,          KC_TRNS,                               KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
   #else
   KC_GRV, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RESET,  \
@@ -66,30 +63,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 enum function_id {
     SHIFT_ESC,
-    #ifdef RGBLIGHT_ENABLE
-    RGBLED_TOGGLE,
-    RGBLED_STEP_MODE,
-    RGBLED_INCREASE_HUE,
-    RGBLED_DECREASE_HUE,
-    RGBLED_INCREASE_SAT,
-    RGBLED_DECREASE_SAT,
-    RGBLED_INCREASE_VAL,
-    RGBLED_DECREASE_VAL
-    #endif
 };
 
 const uint16_t PROGMEM fn_actions[] = {
   [0]  = ACTION_FUNCTION(SHIFT_ESC),
-  #ifdef RGBLIGHT_ENABLE
-  [1]  = ACTION_FUNCTION(RGBLED_TOGGLE),
-  [2]  = ACTION_FUNCTION(RGBLED_STEP_MODE),
-  [3]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
-  [4]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
-  [5]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
-  [6]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
-  [7]  = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
-  [8]  = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
-  #endif
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
@@ -115,48 +92,5 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
         }
       }
       break;
-    //led operations
-    #ifdef RGBLIGHT_ENABLE
-    case RGBLED_TOGGLE:
-      if (record->event.pressed) {
-        rgblight_toggle();
-      }
-      break;
-    case RGBLED_INCREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_increase_hue();
-      }
-      break;
-    case RGBLED_DECREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_decrease_hue();
-      }
-      break;
-    case RGBLED_INCREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_increase_sat();
-      }
-      break;
-    case RGBLED_DECREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_decrease_sat();
-      }
-      break;
-    case RGBLED_INCREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_increase_val();
-      }
-      break;
-    case RGBLED_DECREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_decrease_val();
-      }
-      break;
-    case RGBLED_STEP_MODE:
-      if (record->event.pressed) {
-        rgblight_step();
-      }
-      break;
-    #endif
   }
 }

--- a/keyboards/satan/keymaps/sethbc/keymap.c
+++ b/keyboards/satan/keymaps/sethbc/keymap.c
@@ -1,9 +1,5 @@
 #include "satan.h"
 
-#ifdef RGBLIGHT_ENABLE
-#include "rgblight.h"
-#endif
-
 // Used for SHIFT_ESC
 #define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
 
@@ -44,39 +40,19 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                                     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
   #else
   KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_TRNS, RESET, \
-  KC_CAPS, KC_TRNS, F(1),    F(2),    F(3),    KC_TRNS, KC_TRNS, KC_TRNS, KC_PSCR, KC_SLCK, KC_PAUS, KC_UP,   KC_TRNS, KC_BSPC, \
-  KC_TRNS, KC_VOLD, F(4),    F(5),    F(6),    KC_TRNS, KC_PAST, KC_PSLS, KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT,          KC_PENT, \
-  KC_TRNS,          F(7),    F(8),    KC_TRNS, KC_TRNS, KC_TRNS, KC_PPLS, KC_PMNS, KC_END,  KC_PGDN, KC_DOWN, KC_TRNS, KC_TRNS, \
+  KC_CAPS, KC_TRNS, RGB_TOG,RGB_MOD,RGB_HUI, KC_TRNS, KC_TRNS, KC_TRNS, KC_PSCR, KC_SLCK, KC_PAUS, KC_UP,   KC_TRNS, KC_BSPC, \
+  KC_TRNS, KC_VOLD, RGB_HUD,RGB_SAI,RGB_SAD, KC_TRNS, KC_PAST, KC_PSLS, KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT,          KC_PENT, \
+  KC_TRNS,          RGB_VAI,RGB_VAD,KC_TRNS, KC_TRNS, KC_TRNS, KC_PPLS, KC_PMNS, KC_END,  KC_PGDN, KC_DOWN, KC_TRNS, KC_TRNS, \
   KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                                     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS),
   #endif
 };
 
 enum function_id {
     SHIFT_ESC,
-    #ifdef RGBLIGHT_ENABLE
-    RGBLED_TOGGLE,
-    RGBLED_STEP_MODE,
-    RGBLED_INCREASE_HUE,
-    RGBLED_DECREASE_HUE,
-    RGBLED_INCREASE_SAT,
-    RGBLED_DECREASE_SAT,
-    RGBLED_INCREASE_VAL,
-    RGBLED_DECREASE_VAL
-    #endif
 };
 
 const uint16_t PROGMEM fn_actions[] = {
   [0]  = ACTION_FUNCTION(SHIFT_ESC),
-  #ifdef RGBLIGHT_ENABLE
-  [1]  = ACTION_FUNCTION(RGBLED_TOGGLE),
-  [2]  = ACTION_FUNCTION(RGBLED_STEP_MODE),
-  [3]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
-  [4]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
-  [5]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
-  [6]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
-  [7]  = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
-  [8]  = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
-  #endif
 };
 
 void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
@@ -102,48 +78,5 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
         }
       }
       break;
-    //led operations
-    #ifdef RGBLIGHT_ENABLE
-    case RGBLED_TOGGLE:
-      if (record->event.pressed) {
-        rgblight_toggle();
-      }
-      break;
-    case RGBLED_INCREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_increase_hue();
-      }
-      break;
-    case RGBLED_DECREASE_HUE:
-      if (record->event.pressed) {
-        rgblight_decrease_hue();
-      }
-      break;
-    case RGBLED_INCREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_increase_sat();
-      }
-      break;
-    case RGBLED_DECREASE_SAT:
-      if (record->event.pressed) {
-        rgblight_decrease_sat();
-      }
-      break;
-    case RGBLED_INCREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_increase_val();
-      }
-      break;
-    case RGBLED_DECREASE_VAL:
-      if (record->event.pressed) {
-        rgblight_decrease_val();
-      }
-      break;
-    case RGBLED_STEP_MODE:
-      if (record->event.pressed) {
-        rgblight_step();
-      }
-      break;
-    #endif
   }
 }

--- a/quantum/keymap.h
+++ b/quantum/keymap.h
@@ -156,6 +156,16 @@ enum quantum_keycodes {
     BL_INC,
     BL_TOGG,
     BL_STEP,
+	
+	// RGB functionality
+	RGB_TOG,
+	RGB_MOD,
+	RGB_HUI,
+	RGB_HUD,
+	RGB_SAI,
+	RGB_SAD,
+	RGB_VAI,
+	RGB_VAD,
 
     // Left shift, open paren
     KC_LSPO,

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -93,65 +93,65 @@ bool process_record_quantum(keyrecord_t *record) {
             *(uint16_t *)0x0800 = 0x7777; // these two are a-star-specific
         #endif
         bootloader_jump();
-        return false;
       }
+	  return false;
       break;
     case DEBUG:
       if (record->event.pressed) {
           print("\nDEBUG: enabled.\n");
           debug_enable = true;
-          return false;
       }
+	  return false;
       break;
 	#ifdef RGBLIGHT_ENABLE
 	case RGB_TOG:
 		if (record->event.pressed) {
 			rgblight_toggle();
-			return false;
-		}
-		break;
+      }
+	  return false;
+      break;
 	case RGB_MOD:
 		if (record->event.pressed) {
 			rgblight_step();
-			return false;
-		}
-		break;
+      }
+	  return false;
+      break;
 	case RGB_HUI:
 		if (record->event.pressed) {
 			rgblight_increase_hue();
-			return false;
-		}
-		break;
+      }
+	  return false;
+      break;
 	case RGB_HUD:
 		if (record->event.pressed) {
 			rgblight_decrease_hue();
-			return false;
-		}
-		break;
+      }
+	  return false;
+      break;
 	case RGB_SAI:
 		if (record->event.pressed) {
 			rgblight_increase_sat();
-			return false;
-		}
-		break;
+      }
+	  return false;
+      break;
 	case RGB_SAD:
 		if (record->event.pressed) {
 			rgblight_decrease_sat();
-			return false;
-		}
-		break;
+      }
+	  return false;
+      break;
 	case RGB_VAI:
 		if (record->event.pressed) {
 			rgblight_increase_val();
-			return false;
-		}
-		break;
+      }
+	  return false;
+      break;
 	case RGB_VAD:
 		if (record->event.pressed) {
 			rgblight_decrease_val();
-			return false;
-		}
-		break;
+      }
+	  return false;
+      break;
 	#endif
     case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_UNSWAP_ALT_GUI:
       if (record->event.pressed) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -103,6 +103,56 @@ bool process_record_quantum(keyrecord_t *record) {
           return false;
       }
       break;
+	#ifdef RGBLIGHT_ENABLE
+	case RGB_TOG:
+		if (record->event.pressed) {
+			rgblight_toggle();
+			return false;
+		}
+		break;
+	case RGB_MOD:
+		if (record->event.pressed) {
+			rgblight_step();
+			return false;
+		}
+		break;
+	case RGB_HUI:
+		if (record->event.pressed) {
+			rgblight_increase_hue();
+			return false;
+		}
+		break;
+	case RGB_HUD:
+		if (record->event.pressed) {
+			rgblight_decrease_hue();
+			return false;
+		}
+		break;
+	case RGB_SAI:
+		if (record->event.pressed) {
+			rgblight_increase_sat();
+			return false;
+		}
+		break;
+	case RGB_SAD:
+		if (record->event.pressed) {
+			rgblight_decrease_sat();
+			return false;
+		}
+		break;
+	case RGB_VAI:
+		if (record->event.pressed) {
+			rgblight_increase_val();
+			return false;
+		}
+		break;
+	case RGB_VAD:
+		if (record->event.pressed) {
+			rgblight_decrease_val();
+			return false;
+		}
+		break;
+	#endif
     case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_UNSWAP_ALT_GUI:
       if (record->event.pressed) {
         // MAGIC actions (BOOTMAGIC without the boot)


### PR DESCRIPTION
Moves RGB controls out of the macro function and assigns them their own
keycodes:
RGB_TOG (toggle on/off)
RGB_MOD (mode step)
RGB_HUI (increase hue)
RGB_HUD (decrease hue)
RGB_SAI (increase saturation)
RGB_SAD (decrease saturation)
RGB_VAI (increase brightness)
RGB_VAD (decrease brightness)