### PR TITLE
Port support for hhkb-jp from tmk

### DIFF
--- a/keyboards/hhkb/Makefile
+++ b/keyboards/hhkb/Makefile
@@ -78,6 +78,10 @@ ifndef QUANTUM_DIR
 	include ../../Makefile
 endif
 
+ifneq (, $(findstring yes, $(HHKB_JP)))
+	OPT_DEFS += -DHHKB_JP
+endif
+
 debug-on: EXTRAFLAGS += -DDEBUG -DDEBUG_ACTION
 debug-on: all
 

--- a/keyboards/hhkb/config.h
+++ b/keyboards/hhkb/config.h
@@ -29,7 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DESCRIPTION     q.m.k keyboard firmware for HHKB
 
 /* key matrix size */
-#define MATRIX_ROWS 8
+#ifdef HHKB_JP
+#   define MATRIX_ROWS 16
+#else
+#   define MATRIX_ROWS 8
+#endif
 #define MATRIX_COLS 8
 
 #define TAPPING_TERM    200

--- a/keyboards/hhkb/hhkb.h
+++ b/keyboards/hhkb/hhkb.h
@@ -21,4 +21,31 @@
     { K70, K71, K72, K73, K74, K75, K76, KC_NO }                               \
 }
 
+
+#define KEYMAP_JP(                                                             \
+    K02, K32, K62, K22, K12, K52, K72, KA2, K92, K82, KB2, KE2, KF2, KD2, KC2, \
+    K03, K63, K23, K13, K53, K73, KA3, K93, K83, KB3, KE3, KF3, KD3,           \
+    K06, K66, K26, K16, K56, K76, KA6, K96, K86, KB6, KE6, KF6, KD6, KC6,      \
+    K05, K65, K25, K15, K55, K75, KA5, K95, K85, KB5, KE5, KF5, KD5, KC5,      \
+    K04, K34, K64, K24, K14,      K74,      K94, K84, KB4, KE4, KF4, KD4, KC4) \
+{                                                                              \
+    { KC_NO, KC_NO, K02,   K03,   K04,   K05,   K06,   KC_NO },                \
+    { KC_NO, KC_NO, K12,   K13,   K14,   K15,   K16,   KC_NO },                \
+    { KC_NO, KC_NO, K22,   K23,   K24,   K25,   K26,   KC_NO },                \
+    { KC_NO, KC_NO, K32,   KC_NO, K34,   KC_NO, KC_NO, KC_NO },                \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO },                \
+    { KC_NO, KC_NO, K52,   K53,   KC_NO, K55,   K56,   KC_NO },                \
+    { KC_NO, KC_NO, K62,   K63,   K64,   K65,   K66,   KC_NO },                \
+    { KC_NO, KC_NO, K72,   K73,   K74,   K75,   K76,   KC_NO },                \
+    { KC_NO, KC_NO, K82,   K83,   K84,   K85,   K86,   KC_NO },                \
+    { KC_NO, KC_NO, K92,   K93,   K94,   K95,   K96,   KC_NO },                \
+    { KC_NO, KC_NO, KA2,   KA3,   KC_NO, KA5,   KA6,   KC_NO },                \
+    { KC_NO, KC_NO, KB2,   KB3,   KB4,   KB5,   KB6,   KC_NO },                \
+    { KC_NO, KC_NO, KC2,   KC_NO, KC4,   KC5,   KC6,   KC_NO },                \
+    { KC_NO, KC_NO, KD2,   KD3,   KD4,   KD5,   KD6,   KC_NO },                \
+    { KC_NO, KC_NO, KE2,   KE3,   KE4,   KE5,   KE6,   KC_NO },                \
+    { KC_NO, KC_NO, KF2,   KF3,   KF4,   KF5,   KF6,   KC_NO }                 \
+}
+
+
 #endif

--- a/keyboards/hhkb/keymaps/jp/Makefile
+++ b/keyboards/hhkb/keymaps/jp/Makefile
@@ -1,0 +1,1 @@
+HHKB_JP=yes

--- a/keyboards/hhkb/keymaps/jp/keymap.c
+++ b/keyboards/hhkb/keymaps/jp/keymap.c
@@ -1,0 +1,58 @@
+#include "hhkb.h"
+
+#define _______ KC_TRNS
+
+
+/* Layer 0: HHKB JP
+ * ,-----------------------------------------------------------.
+ * |Esc|  1|  2|  3|  4|  5|  6|  7|  8|  9| 10|  -|  =|Yen|Bsp|
+ * |-----------------------------------------------------------|
+ * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|     |
+ * |------------------------------------------------------` Ent|
+ * |Ctrl  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|  `|    |
+ * |-----------------------------------------------------------|
+ * |Shft   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|  \| Up|Sft|
+ * |-----------------------------------------------------------|
+ * |   ||Ctl|Alt|Cmd|   |   Spc   |Bsp|   |   |   ||Lft|Dwn|Rgh|
+ * `-----------------------------------------------------------'
+ */
+
+/* Layer 1: HHKB mode (HHKB Fn)
+ * ,-----------------------------------------------------------.
+ * |Pwr| F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|Ins|Del|
+ * |-----------------------------------------------------------|
+ * |Caps |   |   |   |   |   |   |   |Psc|Slk|Pus|Up |   |     |
+ * |------------------------------------------------------`    |
+ * |      |VoD|VoU|Mut|   |   |  *|  /|Hom|PgU|Lef|Rig|   |    |
+ * |-----------------------------------------------------------|
+ * |       |   |   |   |   |   |  +|  -|End|PgD|Dow|   |   |   |
+ * |-----------------------------------------------------------|
+ * |   ||   |   |   |   |         |   |   |   |   ||   |   |   |
+ * `-----------------------------------------------------------'
+ */
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = KEYMAP_JP(
+    KC_ESC,   KC_1,    KC_2,    KC_3,    KC_4,     KC_5,    KC_6,    KC_7,     KC_8,    KC_9,    KC_0, KC_MINS,  KC_EQL, KC_JYEN,  KC_BSPC,
+    KC_TAB,   KC_Q,    KC_W,    KC_E,    KC_R,     KC_T,    KC_Y,    KC_U,     KC_I,    KC_O,    KC_P, KC_LBRC, KC_RBRC,
+    KC_LCTL,  KC_A,    KC_S,    KC_D,    KC_F,     KC_G,    KC_H,    KC_J,     KC_K,    KC_L, KC_SCLN, KC_QUOT, KC_BSLS, KC_ENT,
+    KC_LSFT,  KC_Z,    KC_X,    KC_C,    KC_V,     KC_B,    KC_N,    KC_M,  KC_COMM,  KC_DOT, KC_SLSH,   KC_RO,   KC_UP, KC_RSFT,
+    MO(1), KC_ZKHK, KC_LGUI, KC_LALT, KC_MHEN,         KC_SPC,    KC_HENK,  KC_KANA, KC_RALT,   MO(1), KC_LEFT, KC_DOWN, KC_RGHT
+  ),
+
+  [1] = KEYMAP_JP(
+    KC_PWR,    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_F11,  KC_F12,  KC_INS,  KC_DEL,
+    KC_CAPS, _______, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SLCK, KC_PAUS,   KC_UP, _______,
+    _______, KC_VOLD, KC_VOLU, KC_MUTE,  KC_PWR, _______, KC_PAST, KC_PSLS, KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT, _______, KC_PENT,
+    _______, _______, _______, _______, _______, _______, KC_PPLS, KC_PMNS,  KC_END, KC_PGDN, KC_DOWN, _______, _______, _______,
+    _______, _______, _______, _______, _______,     _______     , _______, _______, _______, _______, _______, _______, _______
+  )
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t macro_id, uint8_t opt) {
+  return MACRO_NONE;
+}
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};

--- a/keyboards/hhkb/keymaps/rdg_jp/Makefile
+++ b/keyboards/hhkb/keymaps/rdg_jp/Makefile
@@ -1,0 +1,1 @@
+HHKB_JP=yes

--- a/keyboards/hhkb/keymaps/rdg_jp/keymap.c
+++ b/keyboards/hhkb/keymaps/rdg_jp/keymap.c
@@ -1,0 +1,65 @@
+#include "hhkb.h"
+
+#define _______ KC_TRNS
+
+enum {
+  ZER,
+  HDN,
+  OSY
+};
+
+
+#define CTL_ESC CTL_T(KC_ESC)
+#define SFT_BSP SFT_T(KC_BSPC)
+
+#define SCRNS3 LGUI(LCTL(LSFT(KC_3)))
+#define SCRNS4 LGUI(LCTL(LSFT(KC_4)))
+
+
+/* hhkb jp ~ layout
+ * ,-----------------------------------------------------------.
+ * |Esc|  1|  2|  3|  4|  5|  6|  7|  8|  9| 10|  -|  =|Yen|Bsp|
+ * |-----------------------------------------------------------|
+ * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|     |
+ * |------------------------------------------------------` Ent|
+ * |Ctrl  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|  `|    |
+ * |-----------------------------------------------------------|
+ * |Shft   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|  \| Up|Sft|
+ * |-----------------------------------------------------------|
+ * |   ||Ctl|Alt|Cmd|   |   Spc   |Bsp|   |   |   ||Lft|Dwn|Rgh|
+ * `-----------------------------------------------------------'
+ */
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [ZER] = KEYMAP_JP(
+    KC_ESC,   KC_1,    KC_2,    KC_3,    KC_4,     KC_5,    KC_6,    KC_7,     KC_8,    KC_9,    KC_0, KC_MINS,  KC_EQL, KC_INS,  KC_BSPC,
+    KC_TAB,   KC_Q,    KC_W,    KC_E,    KC_R,     KC_T,    KC_Y,    KC_U,     KC_I,    KC_O,    KC_P, KC_LBRC, KC_RBRC,
+    CTL_ESC,  KC_A,    KC_S,    KC_D,    KC_F,     KC_G,    KC_H,    KC_J,     KC_K,    KC_L, KC_SCLN, KC_QUOT,  KC_GRV, KC_ENT,
+    KC_LSFT,  KC_Z,    KC_X,    KC_C,    KC_V,     KC_B,    KC_N,    KC_M,  KC_COMM,  KC_DOT, KC_SLSH, KC_BSLS,   KC_UP, KC_RSFT,
+    MO(HDN),  KC_LCTL, KC_LALT, KC_LGUI, MO(HDN),      KC_SPC,    SFT_BSP,  MO(HDN), MO(OSY),   KC_NO, KC_LEFT, KC_DOWN, KC_RGHT
+  ),
+
+  [HDN] = KEYMAP_JP(
+    KC_GRV,    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_F11,  KC_F12, _______,  KC_DEL,
+    _______, KC_EXLM,   KC_AT, KC_HASH,  KC_DLR, KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, _______, _______,
+    _______, KC_TILD,  KC_GRV, KC_BSLS, KC_PIPE, KC_MINS, KC_LEFT, KC_DOWN,   KC_UP, KC_RGHT, KC_TILD,  KC_GRV, _______, _______,
+    _______, KC_VOLD, KC_VOLU, KC_MUTE,  KC_PWR, _______, _______,  KC_ENT, _______, _______, _______, _______, KC_PGUP, _______,
+    _______, _______, _______, _______, _______,     KC_UNDS     ,  KC_DEL, _______, _______, _______, KC_HOME, KC_PGDN, KC_END
+  ),
+
+  [OSY] = KEYMAP_JP(
+    _______, _______, _______,  SCRNS3,  SCRNS4, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______,      _______    , _______, _______, _______, _______, _______, _______, _______
+  )
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t macro_id, uint8_t opt) {
+  return MACRO_NONE;
+}
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};


### PR DESCRIPTION
tmk supports the hhkb-jp w/ hasu controller, but it seems the matrix definition was lost sometime after the qmk fork. This brings it back!

To build for the hhkb-jp:
- build with `HHKB_JP=yes` in the Makefile
- use `KEYMAP_JP` in keymap definition 

This includes keymaps for the stock jp layout and my layout.