### PR TITLE
Tap dance anyway

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -70,6 +70,7 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
 
   switch(keycode) {
   case QK_TAP_DANCE ... QK_TAP_DANCE_MAX:
+    process_tap_dance_action_on_each_tap (qk_tap_dance_state.keycode);
     if (qk_tap_dance_state.keycode && qk_tap_dance_state.keycode != keycode) {
       process_tap_dance_action_on_dance_finished (qk_tap_dance_state.keycode);
     } else {
@@ -80,7 +81,6 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
       qk_tap_dance_state.keycode = keycode;
       qk_tap_dance_state.timer = timer_read ();
       qk_tap_dance_state.count++;
-      process_tap_dance_action_on_each_tap (qk_tap_dance_state.keycode);
     }
     break;
 

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -86,6 +86,7 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
 
   default:
     if (qk_tap_dance_state.keycode) {
+      // if we are here, the tap dance was interrupted by a different key
       process_tap_dance_action_on_each_tap (qk_tap_dance_state.keycode);
       process_tap_dance_action_on_dance_finished (qk_tap_dance_state.keycode);
       reset_tap_dance (&qk_tap_dance_state);
@@ -98,6 +99,7 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
 
 void matrix_scan_tap_dance () {
   if (qk_tap_dance_state.keycode && timer_elapsed (qk_tap_dance_state.timer) > TAPPING_TERM) {
+    // if we are here, the tap dance was timed out
     process_tap_dance_action_on_dance_finished (qk_tap_dance_state.keycode);
     reset_tap_dance (&qk_tap_dance_state);
   }

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -22,7 +22,9 @@ static void _process_tap_dance_action_pair (qk_tap_dance_state_t *state,
 static void _process_tap_dance_action_fn (qk_tap_dance_state_t *state,
                                           qk_tap_dance_user_fn_t fn)
 {
-  fn(state);
+  if (fn) {
+    fn(state);
+  }
 }
 
 void process_tap_dance_action (uint16_t keycode)

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -40,7 +40,24 @@ void process_tap_dance_action (uint16_t keycode)
                                     action.pair.kc1, action.pair.kc2);
     break;
   case QK_TAP_DANCE_TYPE_FN:
-    _process_tap_dance_action_fn (&qk_tap_dance_state, action.fn);
+    _process_tap_dance_action_fn (&qk_tap_dance_state, action.fn.regular);
+    break;
+
+  default:
+    break;
+  }
+}
+
+void process_tap_dance_action_anyway (uint16_t keycode)
+{
+  uint16_t idx = keycode - QK_TAP_DANCE;
+  qk_tap_dance_action_t action;
+
+  action = tap_dance_actions[idx];
+
+  switch (action.type) {
+  case QK_TAP_DANCE_TYPE_FN:
+    _process_tap_dance_action_fn (&qk_tap_dance_state, action.fn.anyway);
     break;
 
   default:
@@ -53,6 +70,7 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
 
   switch(keycode) {
   case QK_TAP_DANCE ... QK_TAP_DANCE_MAX:
+    process_tap_dance_action_anyway (qk_tap_dance_state.keycode);
     if (qk_tap_dance_state.keycode && qk_tap_dance_state.keycode != keycode) {
       process_tap_dance_action (qk_tap_dance_state.keycode);
     } else {
@@ -68,6 +86,7 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
 
   default:
     if (qk_tap_dance_state.keycode) {
+      //process_tap_dance_action_anyway (qk_tap_dance_state.keycode);
       process_tap_dance_action (qk_tap_dance_state.keycode);
 
       reset_tap_dance (&qk_tap_dance_state);
@@ -87,6 +106,21 @@ void matrix_scan_tap_dance () {
 }
 
 void reset_tap_dance (qk_tap_dance_state_t *state) {
+  uint16_t idx = state->keycode - QK_TAP_DANCE;
+  qk_tap_dance_action_t action;
+
+  action = tap_dance_actions[idx];
+  switch (action.type) {
+  case QK_TAP_DANCE_TYPE_FN:
+    if (action.fn.reset) {
+      action.fn.reset();
+    }
+    break;
+
+  default:
+    break;
+  }
+
   state->keycode = 0;
   state->count = 0;
 }

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -70,7 +70,6 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
 
   switch(keycode) {
   case QK_TAP_DANCE ... QK_TAP_DANCE_MAX:
-    process_tap_dance_action_on_each_tap (qk_tap_dance_state.keycode);
     if (qk_tap_dance_state.keycode && qk_tap_dance_state.keycode != keycode) {
       process_tap_dance_action_on_dance_finished (qk_tap_dance_state.keycode);
     } else {
@@ -81,12 +80,13 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
       qk_tap_dance_state.keycode = keycode;
       qk_tap_dance_state.timer = timer_read ();
       qk_tap_dance_state.count++;
+      process_tap_dance_action_on_each_tap (qk_tap_dance_state.keycode);
     }
     break;
 
   default:
-    process_tap_dance_action_on_each_tap (qk_tap_dance_state.keycode);
     if (qk_tap_dance_state.keycode) {
+      process_tap_dance_action_on_each_tap (qk_tap_dance_state.keycode);
       process_tap_dance_action_on_dance_finished (qk_tap_dance_state.keycode);
       reset_tap_dance (&qk_tap_dance_state);
     }

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -27,7 +27,24 @@ static void _process_tap_dance_action_fn (qk_tap_dance_state_t *state,
   }
 }
 
-void process_tap_dance_action (uint16_t keycode)
+void process_tap_dance_action_on_each_tap (uint16_t keycode)
+{
+  uint16_t idx = keycode - QK_TAP_DANCE;
+  qk_tap_dance_action_t action;
+
+  action = tap_dance_actions[idx];
+
+  switch (action.type) {
+  case QK_TAP_DANCE_TYPE_FN:
+    _process_tap_dance_action_fn (&qk_tap_dance_state, action.fn.on_each_tap);
+    break;
+
+  default:
+    break;
+  }
+}
+
+void process_tap_dance_action_on_dance_finished (uint16_t keycode)
 {
   uint16_t idx = keycode - QK_TAP_DANCE;
   qk_tap_dance_action_t action;
@@ -40,24 +57,7 @@ void process_tap_dance_action (uint16_t keycode)
                                     action.pair.kc1, action.pair.kc2);
     break;
   case QK_TAP_DANCE_TYPE_FN:
-    _process_tap_dance_action_fn (&qk_tap_dance_state, action.fn.regular);
-    break;
-
-  default:
-    break;
-  }
-}
-
-void process_tap_dance_action_anyway (uint16_t keycode)
-{
-  uint16_t idx = keycode - QK_TAP_DANCE;
-  qk_tap_dance_action_t action;
-
-  action = tap_dance_actions[idx];
-
-  switch (action.type) {
-  case QK_TAP_DANCE_TYPE_FN:
-    _process_tap_dance_action_fn (&qk_tap_dance_state, action.fn.anyway);
+    _process_tap_dance_action_fn (&qk_tap_dance_state, action.fn.on_dance_finished);
     break;
 
   default:
@@ -70,9 +70,9 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
 
   switch(keycode) {
   case QK_TAP_DANCE ... QK_TAP_DANCE_MAX:
-    process_tap_dance_action_anyway (qk_tap_dance_state.keycode);
+    process_tap_dance_action_on_each_tap (qk_tap_dance_state.keycode);
     if (qk_tap_dance_state.keycode && qk_tap_dance_state.keycode != keycode) {
-      process_tap_dance_action (qk_tap_dance_state.keycode);
+      process_tap_dance_action_on_dance_finished (qk_tap_dance_state.keycode);
     } else {
       r = false;
     }
@@ -85,10 +85,9 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
     break;
 
   default:
+    process_tap_dance_action_on_each_tap (qk_tap_dance_state.keycode);
     if (qk_tap_dance_state.keycode) {
-      //process_tap_dance_action_anyway (qk_tap_dance_state.keycode);
-      process_tap_dance_action (qk_tap_dance_state.keycode);
-
+      process_tap_dance_action_on_dance_finished (qk_tap_dance_state.keycode);
       reset_tap_dance (&qk_tap_dance_state);
     }
     break;
@@ -99,8 +98,7 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
 
 void matrix_scan_tap_dance () {
   if (qk_tap_dance_state.keycode && timer_elapsed (qk_tap_dance_state.timer) > TAPPING_TERM) {
-    process_tap_dance_action (qk_tap_dance_state.keycode);
-
+    process_tap_dance_action_on_dance_finished (qk_tap_dance_state.keycode);
     reset_tap_dance (&qk_tap_dance_state);
   }
 }
@@ -112,8 +110,8 @@ void reset_tap_dance (qk_tap_dance_state_t *state) {
   action = tap_dance_actions[idx];
   switch (action.type) {
   case QK_TAP_DANCE_TYPE_FN:
-    if (action.fn.reset) {
-      action.fn.reset();
+    if (action.fn.on_reset) {
+      action.fn.on_reset(state);
     }
     break;
 

--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -22,6 +22,7 @@ typedef enum
 } qk_tap_dance_type_t;
 
 typedef void (*qk_tap_dance_user_fn_t) (qk_tap_dance_state_t *state);
+typedef void (*qk_tap_dance_user_fn_reset_t) (void);
 
 typedef struct
 {
@@ -31,18 +32,37 @@ typedef struct
       uint16_t kc1;
       uint16_t kc2;
     } pair;
-    qk_tap_dance_user_fn_t fn;
+    struct {
+      qk_tap_dance_user_fn_t regular;
+      qk_tap_dance_user_fn_t anyway;
+      qk_tap_dance_user_fn_reset_t reset;
+    } fn;
   };
 } qk_tap_dance_action_t;
 
 #define ACTION_TAP_DANCE_DOUBLE(kc1, kc2) { \
-    .type = QK_TAP_DANCE_TYPE_PAIR,         \
-    .pair = { kc1, kc2 }                    \
+    .type = QK_TAP_DANCE_TYPE_PAIR, \
+    .pair = { kc1, kc2 }            \
   }
 
 #define ACTION_TAP_DANCE_FN(user_fn) { \
     .type = QK_TAP_DANCE_TYPE_FN, \
-    .fn = user_fn                 \
+    .fn = { user_fn, NULL, NULL } \
+  }
+
+#define ACTION_TAP_DANCE_FN_ANYWAY(user_fn, user_fn_anyway) { \
+    .type = QK_TAP_DANCE_TYPE_FN,           \
+    .fn = { user_fn, user_fn_anyway, NULL } \
+  }
+
+#define ACTION_TAP_DANCE_FN_RESET(user_fn, user_fn_reset) { \
+    .type = QK_TAP_DANCE_TYPE_FN,          \
+    .fn = { user_fn, NULL, user_fn_reset } \
+  }
+
+#define ACTION_TAP_DANCE_FN_ANYWAY_RESET(user_fn, user_fn_anyway, user_fn_reset) { \
+    .type = QK_TAP_DANCE_TYPE_FN,                    \
+    .fn = { user_fn, user_fn_anyway, user_fn_reset } \
   }
 
 extern const qk_tap_dance_action_t tap_dance_actions[];

--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -22,7 +22,6 @@ typedef enum
 } qk_tap_dance_type_t;
 
 typedef void (*qk_tap_dance_user_fn_t) (qk_tap_dance_state_t *state);
-typedef void (*qk_tap_dance_user_fn_reset_t) (void);
 
 typedef struct
 {
@@ -33,9 +32,9 @@ typedef struct
       uint16_t kc2;
     } pair;
     struct {
-      qk_tap_dance_user_fn_t regular;
-      qk_tap_dance_user_fn_t anyway;
-      qk_tap_dance_user_fn_reset_t reset;
+      qk_tap_dance_user_fn_t on_each_tap;
+      qk_tap_dance_user_fn_t on_dance_finished;
+      qk_tap_dance_user_fn_t on_reset;
     } fn;
   };
 } qk_tap_dance_action_t;
@@ -45,24 +44,14 @@ typedef struct
     .pair = { kc1, kc2 }            \
   }
 
-#define ACTION_TAP_DANCE_FN(user_fn) { \
+#define ACTION_TAP_DANCE_FN(user_fn) {  \
     .type = QK_TAP_DANCE_TYPE_FN, \
-    .fn = { user_fn, NULL, NULL } \
+    .fn = { NULL, user_fn, NULL } \
   }
 
-#define ACTION_TAP_DANCE_FN_ANYWAY(user_fn, user_fn_anyway) { \
-    .type = QK_TAP_DANCE_TYPE_FN,           \
-    .fn = { user_fn, user_fn_anyway, NULL } \
-  }
-
-#define ACTION_TAP_DANCE_FN_RESET(user_fn, user_fn_reset) { \
-    .type = QK_TAP_DANCE_TYPE_FN,          \
-    .fn = { user_fn, NULL, user_fn_reset } \
-  }
-
-#define ACTION_TAP_DANCE_FN_ANYWAY_RESET(user_fn, user_fn_anyway, user_fn_reset) { \
-    .type = QK_TAP_DANCE_TYPE_FN,                    \
-    .fn = { user_fn, user_fn_anyway, user_fn_reset } \
+#define ACTION_TAP_DANCE_FN_ADVANCED(user_fn_on_each_tap, user_fn_on_dance_finished, user_fn_on_reset) { \
+    .type = QK_TAP_DANCE_TYPE_FN,                                              \
+    .fn = { user_fn_on_each_tap, user_fn_on_dance_finished, user_fn_on_reset } \
   }
 
 extern const qk_tap_dance_action_t tap_dance_actions[];


### PR DESCRIPTION
when using tap dance, we have the `regular` callback that is called on
the last tap. this commit adds an `anyway` callback that is called on
every tap, and a `reset` callback that is called on reset of the tap
dance taps.

use case: i want the following. one button is going to be the reset button, when i press it three times using tap dance. here is the need for anyway and reset. every time i tap it, one of the leds should go on.
```
enum {
  CT_RST = 0,
};

...

[BASE] = KEYMAP(
 TD(CT_RST) ,KC_NO  ,KC_NO

...

void dance_rst(qk_tap_dance_state_t *state) {
  if (state->count >= 3) {
    reset_keyboard();
    reset_tap_dance(state);
  }
}

void dance_rst_anyway(qk_tap_dance_state_t *state) {
  if (state->count == 1) {
    ergodox_right_led_3_on();
  } else if (state->count == 2) {
      ergodox_right_led_2_on();
  } else if (state->count == 3) {
    ergodox_right_led_1_on();
  }
}

void dance_rst_reset(void) {
  ergodox_led_all_off();
}

...

const qk_tap_dance_action_t tap_dance_actions[] = {
  [CT_RST] = ACTION_TAP_DANCE_FN_ANYWAY_RESET(dance_rst, dance_rst_anyway, dance_rst_reset)
};
```
when i tap the reset button once, the first led should go on, then if i dont press again, the reset is called, and my callback turns the leds off.
when i tap twice, the first led will go on with the first tap, the second will go on with the second tap, etc.
on the third tap, the third led turns on, and afterwards the keyboard will go to reset/flash mode.

some feedback from @algernon is needed.

these are the changes:
- add `qk_tap_dance_user_fn_reset_t` type. maybe we dont need it and we just use `qk_tap_dance_user_fn_t`? i just thought reset doesnt need the count or anything from the state.
- made a struct for the `fn` case, that holds the `regular` fn called on the final tap, the `anyway` fn called on every tap, and the `reset` fn called on tap dance reset.
- added `ACTION_TAP_DANCE_FN_ANYWAY`, `ACTION_TAP_DANCE_FN_RESET`, `ACTION_TAP_DANCE_FN_ANYWAY_RESET` macros for tap dance actions initialization. maybe we can just use `ACTION_TAP_DANCE_FN` with different number of args? variable args or overriding, or just always three args..?
- on tap dance reset, i call `action.fn.reset`.
- `process_tap_dance_action_anyway` is the way i call the `anyway` function. im not sure if where its called is correct or if it should be inside some check from the `if` below. also the commented call, i dont know if we need it. when does the `default` case get executed?

what do you think for each of those points?
thanks.