### PR TITLE
Make DFU wait for bootloader

### DIFF
--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -107,6 +107,10 @@ flip: $(BUILD_DIR)/$(TARGET).hex
 	batchisp -hardware usb -device $(MCU) -operation start reset 0
 
 dfu: $(BUILD_DIR)/$(TARGET).hex sizeafter
+	until dfu-programmer $(MCU) get bootloader-version; do\
+		echo "Error: Bootloader not found. Trying again in 5s." ;\
+		sleep 5 ;\
+	done
 ifneq (, $(findstring 0.7, $(shell dfu-programmer --version 2>&1)))
 	dfu-programmer $(MCU) erase --force
 else


### PR DESCRIPTION
Added a loop for waiting for the keyboard to be put in bootloader mode,
rather than failing out. Makes building keymaps easier.

Only tested on OS X, will need further testing.