### PR TITLE
Added Docker as a simple way to build firmwares

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:jessie
+MAINTAINER Erik Dasque <erik@frenchguys.com>
+
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y build-essential \
+    gcc \
+    unzip \
+    wget \
+    zip \
+    gcc-avr \
+    binutils-avr \
+    avr-libc \
+    dfu-programmer \
+    dfu-util \
+    gcc-arm-none-eabi \
+    binutils-arm-none-eabi \
+    libnewlib-arm-none-eabi \
+    git
+
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+
+ENV keyboard=ergodox_ez
+ENV keymap=default
+
+VOLUME /qmk
+WORKDIR /qmk
+CMD make clean ; make keyboard=${keyboard} keymap=${keymap}

--- a/readme.md
+++ b/readme.md
@@ -77,18 +77,14 @@ Debian/Ubuntu example:
 
 ### Docker
 
-If this is a bit complex for you, Docker might be the turn-key solution you need. After installing [Docker](https://www.docker.com/products/docker), run the following commands at the root of the QMK folder:
+If this is a bit complex for you, Docker might be the turn-key solution you need. After installing [Docker](https://www.docker.com/products/docker), run the following command at the root of the QMK folder to build a keyboard/keymap:
 
 ```bash
-# You only need to run this once, it'll take a little while
-
-docker build -t qmk .
-
-# and you'll run this every time you want to build a keymap
+# You'll run this every time you want to build a keymap
 # modify the keymap and keyboard assigment to compile what you want
 # defaults are ergodox_ez/default
 
-docker run -e keymap=gwen -e keyboard=ergodox_ez --rm -v $('pwd'):/qmk:rw qmk
+docker run -e keymap=gwen -e keyboard=ergodox_ez --rm -v $('pwd'):/qmk:rw edasque/qmk_firmware
 
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,25 @@ Debian/Ubuntu example:
     sudo apt-get update
     sudo apt-get install gcc-avr avr-libc dfu-programmer
 
+### Docker
+
+If this is a bit complex for you, Docker might be the turn-key solution you need. After installing [Docker](https://www.docker.com/products/docker), run the following commands at the root of the QMK folder:
+
+```bash
+# You only need to run this once, it'll take a little while
+
+docker build -t qmk .
+
+# and you'll run this every time you want to build a keymap
+# modify the keymap and keyboard assigment to compile what you want
+# defaults are ergodox_ez/default
+
+docker run -e keymap=gwen -e keyboard=ergodox_ez --rm -v $('pwd'):/qmk:rw qmk
+
+```
+
+This will compile the targetted keyboard/keymap and leave it in your QMK directory for you to flash.
+
 ### Vagrant
 If you have any problems building the firmware, you can try using a tool called Vagrant. It will set up a virtual computer with a known configuration that's ready-to-go for firmware building. OLKB does NOT host the files for this virtual computer. Details on how to set up Vagrant are in the [VAGRANT_GUIDE file](VAGRANT_GUIDE.md).
 


### PR DESCRIPTION
While Vagrant works well, it'll a little complex and gruesome to set up. For this particular use case, I felt Docker is a great fit and is quite seamless.

Building a keyboard/keymap ends up being as simple as running
```bash
docker run -e keymap=gwen -e keyboard=ergodox_ez --rm -v $('pwd'):/qmk:rw edasque/qmk_firmware
```

We'll be able to change the image user name if you set up a trigger on hub.docker.com to build an official image (trivial).

Would love to get your feedback.
