### PR TITLE
Adjusted Atreus KEYMAP() function.

### DIFF
--- a/keyboards/atreus/atreus.h
+++ b/keyboards/atreus/atreus.h
@@ -10,16 +10,16 @@
 // The first section contains all of the arguements
 // The second converts the arguments into a two-dimensional array
 #define KEYMAP( \
-  k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, \
-  k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, \
-  k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, \
-  k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a \
+  k00, k01, k02, k03, k04,           k05, k06, k07, k08, k09, \
+  k10, k11, k12, k13, k14,           k15, k16, k17, k18, k19, \
+  k20, k21, k22, k23, k24,           k25, k26, k27, k28, k29, \
+  k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b \
 ) \
 { \
 	{ k00, k01, k02, k03, k04, KC_NO, k05, k06, k07, k08, k09 }, \
 	{ k10, k11, k12, k13, k14, KC_NO, k15, k16, k17, k18, k19 }, \
 	{ k20, k21, k22, k23, k24, k35,   k25, k26, k27, k28, k29 }, \
-	{ k2a, k30, k31, k32, k33, k34,   k36, k37, k38, k39, k3a } \
+	{ k30, k31, k32, k33, k34, k36,   k37, k38, k39, k3a, k3b } \
 }
 
 #endif


### PR DESCRIPTION
This change adjusts the KEYMAP() function to provide a more visual representation of the key positions on the keyboard. Previously, keymaps have been defined directly using arrays for the Atreus keyboard. While this works, it doesn't utilize the helpful KEYMAP() function at all to allow the user to visually position the key codes for ease of editing. See the Ergodox-EZ KEYMAP() function and layouts for a great example of how this can work.

This change should not break any existing Atreus layouts. At the time of this commit, there are two existing layouts for the Atreus board, and neither use the KEYMAP() function.

I'm working on a layout for the Atreus right now that I will submit as soon as it's relatively stable. That layout should show an example of using this function.