### PR TITLE
Tap-dance: support for holding keys

### DIFF
--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -17,42 +17,34 @@ typedef struct
 
 #define TD(n) (QK_TAP_DANCE + n)
 
-typedef enum
-{
-  QK_TAP_DANCE_TYPE_PAIR,
-  QK_TAP_DANCE_TYPE_FN,
-} qk_tap_dance_type_t;
-
-typedef void (*qk_tap_dance_user_fn_t) (qk_tap_dance_state_t *state);
+typedef void (*qk_tap_dance_user_fn_t) (qk_tap_dance_state_t *state, void *user_data);
 
 typedef struct
 {
-  qk_tap_dance_type_t type;
-  union {
-    struct {
-      uint16_t kc1;
-      uint16_t kc2;
-    } pair;
-    struct {
-      qk_tap_dance_user_fn_t on_each_tap;
-      qk_tap_dance_user_fn_t on_dance_finished;
-      qk_tap_dance_user_fn_t on_reset;
-    } fn;
-  };
+  struct {
+    qk_tap_dance_user_fn_t on_each_tap;
+    qk_tap_dance_user_fn_t on_dance_finished;
+    qk_tap_dance_user_fn_t on_reset;
+  } fn;
+  void *user_data;
 } qk_tap_dance_action_t;
 
+typedef struct
+{
+  uint16_t kc1;
+  uint16_t kc2;
+} qk_tap_dance_pair_t;
+
 #define ACTION_TAP_DANCE_DOUBLE(kc1, kc2) { \
-    .type = QK_TAP_DANCE_TYPE_PAIR, \
-    .pair = { kc1, kc2 }            \
+    .fn = { NULL, qk_tap_dance_pair_finished, qk_tap_dance_pair_reset }, \
+    .user_data = (void *)&((qk_tap_dance_pair_t) { kc1, kc2 })  \
   }
 
 #define ACTION_TAP_DANCE_FN(user_fn) {  \
-    .type = QK_TAP_DANCE_TYPE_FN, \
     .fn = { NULL, user_fn, NULL } \
   }
 
 #define ACTION_TAP_DANCE_FN_ADVANCED(user_fn_on_each_tap, user_fn_on_dance_finished, user_fn_on_reset) { \
-    .type = QK_TAP_DANCE_TYPE_FN,                                              \
     .fn = { user_fn_on_each_tap, user_fn_on_dance_finished, user_fn_on_reset } \
   }
 
@@ -63,6 +55,9 @@ extern const qk_tap_dance_action_t tap_dance_actions[];
 bool process_tap_dance(uint16_t keycode, keyrecord_t *record);
 void matrix_scan_tap_dance (void);
 void reset_tap_dance (qk_tap_dance_state_t *state);
+
+void qk_tap_dance_pair_finished (qk_tap_dance_state_t *state, void *user_data);
+void qk_tap_dance_pair_reset (qk_tap_dance_state_t *state, void *user_data);
 
 #else
 

--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -11,6 +11,8 @@ typedef struct
   uint8_t count;
   uint16_t keycode;
   uint16_t timer;
+  bool active:1;
+  bool pressed:1;
 } qk_tap_dance_state_t;
 
 #define TD(n) (QK_TAP_DANCE + n)

--- a/readme.md
+++ b/readme.md
@@ -373,7 +373,7 @@ As you can see, you have three function. you can use - `SEQ_ONE_KEY` for single-
 
 ### Tap Dance: A single key can do 3, 5, or 100 different things
 
-Hit the semicolon key once, send a semicolon. Hit it twice, rapidly -- send a colon. Hit it three times, and your keyboard's LEDs do a wild dance. That's just one example of what Tap Dance can do. It's one of the nicest community-contributed features in the firmware, conceived and created by [algernon](https://github.com/algernon) in [#451](https://github.com/jackhumbert/qmk_firmware/pull/451). Here's how Algernon describes the feature:
+Hit the semicolon key once, send a semicolon. Hit it twice, rapidly -- send a colon. Hit it three times, and your keyboard's LEDs do a wild dance. That's just one example of what Tap Dance can do. It's one of the nicest community-contributed features in the firmware, conceived and created by [algernon](https://github.com/algernon) in [#451](https://github.com/jackhumbert/qmk_firmware/pull/451). Here's how algernon describes the feature:
 
 With this feature one can specify keys that behave differently, based on the amount of times they have been tapped, and when interrupted, they get handled before the interrupter.
 

--- a/readme.md
+++ b/readme.md
@@ -389,15 +389,13 @@ First, you will need `TAP_DANCE_ENABLE=yes` in your `Makefile`, because the feat
 
 This array specifies what actions shall be taken when a tap-dance key is in action. Currently, there are three possible options:
 
-* `ACTION_TAP_DANCE_DOUBLE(kc1, kc2)`: Sends the `kc1` keycode when tapped once, `kc2` otherwise.
+* `ACTION_TAP_DANCE_DOUBLE(kc1, kc2)`: Sends the `kc1` keycode when tapped once, `kc2` otherwise. When the key is held, the appropriate keycode is registered: `kc1` when pressed and held, `kc2` when tapped once, then pressed and held.
 * `ACTION_TAP_DANCE_FN(fn)`: Calls the specified function - defined in the user keymap - with the final tap count of the tap dance action.
 * `ACTION_TAP_DANCE_FN_ADVANCED(on_each_tap_fn, on_dance_finished_fn, on_reset_fn)`: Calls the first specified function - defined in the user keymap - on every tap, the second function on when the dance action finishes (like the previous option), and the last function when the tap dance action resets.
 
 The first option is enough for a lot of cases, that just want dual roles. For example, `ACTION_TAP_DANCE(KC_SPC, KC_ENT)` will result in `Space` being sent on single-tap, `Enter` otherwise.
 
 And that's the bulk of it!
-
-Do note, however, that this implementation does have some consequences: keys do not register until either they reach the tapping ceiling, or they time out. This means that if you hold the key, nothing happens, no repeat, no nothing. It is possible to detect held state, and register an action then too, but that's not implemented yet. Keys also unregister immediately after being registered, so you can't even hold the second tap. This is intentional, to be consistent.
 
 And now, on to the explanation of how it works!
 
@@ -421,20 +419,25 @@ enum {
 
 /* Have the above three on the keymap, TD(CT_SE), etc... */
 
-void dance_cln (qk_tap_dance_state_t *state) {
+void dance_cln_finished (qk_tap_dance_state_t *state, void *user_data) {
   if (state->count == 1) {
     register_code (KC_RSFT);
     register_code (KC_SCLN);
-    unregister_code (KC_SCLN);
-    unregister_code (KC_RSFT);
   } else {
     register_code (KC_SCLN);
-    unregister_code (KC_SCLN);
-    reset_tap_dance (state);
   }
 }
 
-void dance_egg (qk_tap_dance_state_t *state) {
+void dance_cln_reset (qk_tap_dance_state_t *state, void *user_data) {
+  if (state->count == 1) {
+    unregister_code (KC_RSFT);
+    unregister_code (KC_SCLN);
+  } else {
+    unregister_code (KC_SCLN);
+  }
+}
+
+void dance_egg (qk_tap_dance_state_t *state, void *user_data) {
   if (state->count >= 100) {
     SEND_STRING ("Safety dance!");
     reset_tap_dance (state);
@@ -443,7 +446,7 @@ void dance_egg (qk_tap_dance_state_t *state) {
 
 // on each tap, light up one led, from right to left
 // on the forth tap, turn them off from right to left
-void dance_flsh_each(qk_tap_dance_state_t *state) {
+void dance_flsh_each(qk_tap_dance_state_t *state, void *user_data) {
   switch (state->count) {
   case 1:
     ergodox_right_led_3_on();
@@ -464,7 +467,7 @@ void dance_flsh_each(qk_tap_dance_state_t *state) {
 }
 
 // on the fourth tap, set the keyboard on flash state
-void dance_flsh_finished(qk_tap_dance_state_t *state) {
+void dance_flsh_finished(qk_tap_dance_state_t *state, void *user_data) {
   if (state->count >= 4) {
     reset_keyboard();
     reset_tap_dance(state);
@@ -472,7 +475,7 @@ void dance_flsh_finished(qk_tap_dance_state_t *state) {
 }
 
 // if the flash state didnt happen, then turn off leds, left to right
-void dance_flsh_reset(qk_tap_dance_state_t *state) {
+void dance_flsh_reset(qk_tap_dance_state_t *state, void *user_data) {
   ergodox_right_led_1_off();
   _delay_ms(50);
   ergodox_right_led_2_off();
@@ -482,7 +485,7 @@ void dance_flsh_reset(qk_tap_dance_state_t *state) {
 
 const qk_tap_dance_action_t tap_dance_actions[] = {
   [CT_SE]  = ACTION_TAP_DANCE_DOUBLE (KC_SPC, KC_ENT)
- ,[CT_CLN] = ACTION_TAP_DANCE_FN (dance_cln)
+ ,[CT_CLN] = ACTION_TAP_DANCE_FN_ADVANCED (NULL, dance_cln_finished, dance_cln_reset)
  ,[CT_EGG] = ACTION_TAP_DANCE_FN (dance_egg)
  ,[CT_FLSH] = ACTION_TAP_DANCE_FN_ADVANCED (dance_flsh_each, dance_flsh_finished, dance_flsh_reset)
 };


### PR DESCRIPTION
This is based on - and includes - #516, the great work of @pvinis. What it does, is that it records the pressed state of the tap key in the state, so that the `on_finished` and `on_reset` callbacks can make use of it.

And indeed, the `ACTION_TAP_DANCE_DOUBLE` helper has been modified so that it registers the key as soon as possible, and unregisters when the dance is reset. This allows one to do hold a tap key, and get the first keycode, or tap it once and then hold to get the second key, held in both cases, and only get one of them.

The compromise here is that the key will register after a timeout of `TAPPING_TERM`, so it will start repeating a little later than otherwise.

The documentation and the example has been updated accordingly.

I also cleaned up the code a little... well, redesigned it a bit. There is now only what was formerly the `QK_TAP_DANCE_TYPE_FN`, and the callbacks receive a `user_data` argument. The `ACTION_TAP_DANCE_DOUBLE` helper puts a pointer to a two-value struct into the `user_data`, to know which keys to register.

This also makes it possible to pass custom parameters - kind of - to callback functions, which makes them easier to reuse, or parameterize.

I have been testing this for the past few hours, and it appears stable, but I'd still consider these changes experimental. A few days of testing, or testing by others too, would do it good. (The base of it, #516, is rock solid, though!)