### PR TITLE
Fix misspelled command in Norwegian helper

### DIFF
--- a/quantum/keymap_extras/keymap_nordic.h
+++ b/quantum/keymap_extras/keymap_nordic.h
@@ -25,7 +25,7 @@
 #define NO_SECT LSFT(NO_HALF)
 #define NO_QUO2	LSFT(KC_2)
 #define NO_BULT LSFT(KC_4)
-#define NO_AMP	LSFT(KC_6)
+#define NO_AMPR	LSFT(KC_6)
 #define NO_SLSH LSFT(KC_7)
 #define NO_LPRN	LSFT(KC_8)
 #define NO_RPRN	LSFT(KC_9)

--- a/quantum/keymap_extras/keymap_norwegian.h
+++ b/quantum/keymap_extras/keymap_norwegian.h
@@ -13,7 +13,7 @@
 #undef NO_BSLS
 #define NO_BSLS KC_EQL  // '\'
 #undef NO_CIRC
-#define NO_CIRC LSFT(C_RBRC)  // ^
+#define NO_CIRC LSFT(KC_RBRC)  // ^
 #undef NO_GRV
 #define NO_GRV	LSFT(NO_BSLS)  //
 #undef NO_OSLH


### PR DESCRIPTION
It said `C_` instead of `KC_`