### PR TITLE
Allow toggling out of plover layer

### DIFF
--- a/keyboards/ergodox_ez/keymaps/plover/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/plover/keymap.c
@@ -160,7 +160,7 @@ KEYMAP(
 [PLVR] = KEYMAP(  // layout: layer 4: Steno for Plover
         // left hand
         KC_NO, KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,
-        KC_NO,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_NO,
+        KC_NO,  KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_TRNS,
         KC_NO,  KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,
         KC_NO,  KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_NO,
         KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,
@@ -169,7 +169,7 @@ KEYMAP(
                                  KC_C,   KC_V,   KC_NO,
         // right hand
              KC_TRNS,  KC_NO,   KC_NO,   KC_NO,  KC_NO,   KC_NO,   KC_TRNS,
-               KC_NO,   KC_6,    KC_7,    KC_8,   KC_9,    KC_0,   KC_TRNS,
+             KC_TRNS,   KC_6,    KC_7,    KC_8,   KC_9,    KC_0,   KC_TRNS,
                         KC_Y,   KC_U,    KC_I,    KC_O,   KC_P,    KC_LBRC,
                KC_NO,   KC_H,    KC_J,    KC_K,   KC_L, KC_SCLN,   KC_QUOT,
                               KC_TRNS, KC_TRNS,  KC_NO,   KC_NO,     KC_NO,


### PR DESCRIPTION
Currently when you switch to the plover layer, you can't switch back to the original layer. This fixes that.