### PR TITLE
kill warnings filling up travis buildlog

### DIFF
--- a/keyboards/satan/keymaps/stanleylai/config.h
+++ b/keyboards/satan/keymaps/stanleylai/config.h
@@ -1,20 +1,15 @@
 #include "../../config.h"
 
-// USB Device descriptor parameter
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6060
-#define DEVICE_VER      0x0003
-#define MANUFACTURER    Custom
-#define PRODUCT         GH60 rev.CHN
-#define DESCRIPTION     QMK keyboard firmware for GH60 with WS2812 support
-
 // Backlight configuration
+#undef BACKLIGHT_LEVELS
 #define BACKLIGHT_LEVELS 3
 
 // Underlight configuration
-#define RGB_DI_PIN E2
-#define RGBLIGHT_TIMER
+#undef RGBLED_NUM
 #define RGBLED_NUM 6        // Number of LEDs
+#undef RGBLIGHT_HUE_STEP
 #define RGBLIGHT_HUE_STEP 8
+#undef RGBLIGHT_SAT_STEP
 #define RGBLIGHT_SAT_STEP 8
+#undef RGBLIGHT_VAL_STEP
 #define RGBLIGHT_VAL_STEP 8


### PR DESCRIPTION
Fix warnings:
- No need to change the USB device descriptor
- Remove unchanged previously defined values