### PR TITLE
Update some obsolete references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install --no-install-recommends -y build-essential \
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
-ENV keyboard=ergodox_ez
+ENV keyboard=ergodox
 ENV keymap=default
 
 VOLUME /qmk

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,7 @@ Vagrant.configure(2) do |config|
 
   Or you can copy and paste the example line below.
 
-  cd /vagrant; cd keyboards; cd ergodox_ez; make clean; make
+  cd /vagrant; cd keyboards; cd ergodox; make clean; make
 
 
   EOT

--- a/doc/TMK_README.md
+++ b/doc/TMK_README.md
@@ -34,7 +34,7 @@ You can find some keyboard specific projects under `converter` and `keyboard` di
 * [atomic](keyboards/atomic/)                - [Atomic] Ortholinear 60% keyboard
 
 ### Ergodox EZ
-* [ergodox_ez](keyboards/ergodox_ez)         - [Ergodox_EZ] Assembled split keyboard
+* [ergodox_ez](keyboards/ergodox/ez)         - [Ergodox_EZ] Assembled split keyboard
 
 ## Other projects
 

--- a/doc/VAGRANT_GUIDE.md
+++ b/doc/VAGRANT_GUIDE.md
@@ -20,7 +20,7 @@ See [/doc/keymap.md](/doc/keymap.md).
 
 ## Flashing the firmware
 
-The "easy" way to flash the firmware is using a tool from your host OS like the Teensy programming app. [ErgoDox EZ](/keyboards/ergodox_ez/readme.md) gives a great example.
+The "easy" way to flash the firmware is using a tool from your host OS like the Teensy programming app. [ErgoDox EZ](/keyboards/ergodox/readme.md) gives a great example.
 
 If you want to program via the command line you can uncomment the ['modifyvm'] lines in the Vagrantfile to enable the USB passthrough into Linux and then program using the command line tools like dfu-util/dfu-programmer or you can install the Teensy CLI version.
 	

--- a/keyboards/ergodox/keymaps/supercoder/readme.md
+++ b/keyboards/ergodox/keymaps/supercoder/readme.md
@@ -23,7 +23,7 @@ your own:
 
 ```
 $ git clone https://github.com/jackhumbert/qmk_firmware.git
-$ cd qmk_firmware/keyboards/ergodox_ez
+$ cd qmk_firmware/keyboards/ergodox
 $ git clone https://github.com/algernon/ergodox-supercoder.git keymaps/supercoder
 $ make KEYMAP=supercoder
 ```

--- a/keyboards/readme.md
+++ b/keyboards/readme.md
@@ -17,7 +17,7 @@ What makes OLKB keyboards shine is a combo of lean aesthetics, compact size, and
 
 Made in Taiwan using advanced robotic manufacturing, the ErgoDox EZ is a fully-assembled, premium ergonomic keyboard. Its split design allows you to place both halves shoulder width, and its custom-made wrist rests and tilt/tent kit make for incredibly comfortable typing. Available on [ergodox-ez.com](https://ergodox-ez.com).
 
-* [ErgoDox EZ](/keyboards/ergodox_ez/) - Our one and only product. Yes, it's that awesome. Comes with either printed or blank keycaps, and 7 different keyswitch types.
+* [ErgoDox EZ](/keyboards/ergodox/) - Our one and only product. Yes, it's that awesome. Comes with either printed or blank keycaps, and 7 different keyswitch types.
 
 ### Clueboard - Zach White
 

--- a/readme.md
+++ b/readme.md
@@ -82,9 +82,9 @@ If this is a bit complex for you, Docker might be the turn-key solution you need
 ```bash
 # You'll run this every time you want to build a keymap
 # modify the keymap and keyboard assigment to compile what you want
-# defaults are ergodox_ez/default
+# defaults are ergodox/default
 
-docker run -e keymap=gwen -e keyboard=ergodox_ez --rm -v $('pwd'):/qmk:rw edasque/qmk_firmware
+docker run -e keymap=gwen -e keyboard=ergodox --rm -v $('pwd'):/qmk:rw edasque/qmk_firmware
 
 ```
 


### PR DESCRIPTION
Some links were still pointing to `/keyboards/ergodox_ez`, while the directory is `/keyboards/erdogox` now.

Not all references have been updated, and some of the text here and there may need updating to mention the ErgoDox Infinity too, but that's out of the scope for this quick fix.

Without this, the qmk.fm site's ErgoDox (EZ) section is not easily discoverable, because no links point to the right place.