### PR TITLE
Fix makefile include guards and change output to $(TMK_ROOT).build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,8 @@ ifdef SUBPROJECT
 else
 	TARGET ?= $(KEYBOARD)_$(KEYMAP)
 endif
-BUILD_DIR = .build
+
+BUILD_DIR = $(TOP_DIR)/.build
 
 # Object files directory
 #     To put object files in current directory, use a dot (.), do NOT make

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ endif
 .DEFAULT_GOAL := all
 
 space := $(subst ,, )
-starting_makefile := $(subst $(space),_SPACE_,$(abspath $(firstword $(MAKEFILE_LIST))))
-mkfile_path := $(subst $(space),_SPACE_,$(abspath $(lastword $(MAKEFILE_LIST))))
+ESCAPED_ABS_PATH = $(subst $(space),_SPACE_,$(abspath $1))
+starting_makefile := $(call ESCAPED_ABS_PATH,$(firstword $(MAKEFILE_LIST)))
+mkfile_path := $(call ESCAPED_ABS_PATH,$(lastword $(MAKEFILE_LIST))))
 abs_tmk_root := $(patsubst %/,%,$(dir $(mkfile_path)))
 
 ifneq (,$(findstring /keyboards/,$(starting_makefile)))
@@ -83,10 +84,8 @@ endif
 
 ifneq ("$(wildcard $(KEYBOARD_PATH)/$(KEYBOARD).c)","")
 	KEYBOARD_FILE = keyboards/$(KEYBOARD)/$(KEYBOARD).c
-	ifndef ARCH
-		ifneq ("$(wildcard $(KEYBOARD_PATH)/Makefile)","")
-			include $(KEYBOARD_PATH)/Makefile
-		endif
+	ifneq ($(call ESCAPED_ABS_PATH,$(KEYBOARD_PATH)/Makefile),$(starting_makefile))
+		-include $(KEYBOARD_PATH)/Makefile
 	endif
 else 
 $(error "$(KEYBOARD_PATH)/$(KEYBOARD).c" does not exist)
@@ -101,7 +100,9 @@ ifdef SUBPROJECT
 	ifneq ("$(wildcard $(SUBPROJECT_PATH)/$(SUBPROJECT).c)","")
 		OPT_DEFS += -DSUBPROJECT_$(SUBPROJECT)
 		SUBPROJECT_FILE = keyboards/$(KEYBOARD)/$(SUBPROJECT)/$(SUBPROJECT).c
-		-include $(SUBPROJECT_PATH)/Makefile
+		ifneq ($(call ESCAPED_ABS_PATH,$(SUBPROJECT_PATH)/Makefile),$(starting_makefile))
+			-include $(SUBPROJECT_PATH)/Makefile
+		endif
 	else 
 $(error "$(SUBPROJECT_PATH)/$(SUBPROJECT).c" does not exist)
 	endif
@@ -119,14 +120,18 @@ endif
 KEYMAP_PATH = $(KEYBOARD_PATH)/keymaps/$(KEYMAP)
 ifneq ("$(wildcard $(KEYMAP_PATH)/keymap.c)","")
 	KEYMAP_FILE = keyboards/$(KEYBOARD)/keymaps/$(KEYMAP)/keymap.c
-	-include $(KEYMAP_PATH)/Makefile
+	ifneq ($(call ESCAPED_ABS_PATH,$(KEYMAP_PATH)/Makefile),$(starting_makefile))
+		-include $(KEYMAP_PATH)/Makefile
+	endif
 else 
 	ifeq ("$(wildcard $(SUBPROJECT_PATH)/keymaps/$(KEYMAP)/keymap.c)","")
 $(error "$(KEYMAP_PATH)/keymap.c" does not exist)
 	else
 		KEYMAP_PATH = $(SUBPROJECT_PATH)/keymaps/$(KEYMAP)
 		KEYMAP_FILE = keyboards/$(KEYBOARD)/$(SUBPROJECT)/keymaps/$(KEYMAP)/keymap.c
-		-include $(KEYMAP_PATH)/Makefile
+		ifneq ($(call ESCAPED_ABS_PATH,$(KEYMAP_PATH)/Makefile),$(starting_makefile))
+			-include $(KEYMAP_PATH)/Makefile
+		endif
 	endif
 endif
 

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -15,6 +15,16 @@
 # Carlos Lamas
 #
 
+# Enable vpath seraching for source files only
+# Without this, output files, could be read from the wrong .build directories
+VPATH_SRC := $(VPATH)
+vpath %.c $(VPATH_SRC)
+vpath %.h $(VPATH_SRC)
+vpath %.cpp $(VPATH_SRC)
+vpath %.hpp $(VPATH_SRC)
+vpath %.S $(VPATH_SRC)
+VPATH :=
+
 
 # Output format. (can be srec, ihex, binary)
 FORMAT = ihex
@@ -71,7 +81,7 @@ BUILD_CMD = LOG=$$($(CMD) 2>&1) ; if [ $$? -gt 0 ]; then $(PRINT_ERROR); elif [ 
 #     Each directory must be seperated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
-EXTRAINCDIRS += $(subst :, ,$(VPATH))
+EXTRAINCDIRS += $(subst :, ,$(VPATH_SRC))
 
 
 # Compiler flag to set the C Standard level.


### PR DESCRIPTION
I noticed a problem when building the ez keyboards from the ez subfolder. For me the compilation was failing on this machine, although Travis said everything was ok.

Upon further investigation it turned out that the keyboard makefile was not included at all, as the ARCH variable was defined in the sub-project. So I changed the way that the include guards are handled for the makefile.

I also found the actual reason why Travis doesn't complain. Our VPATH directives will make the build system find the output files from the wrong directories in some cases. It therefore determined that nothing needed to be re-built and didn't complain about the error. For me on the other hand, it determined that compilation was needed and gave an error.

Finally I force the output to the $(TMK_ROOT)/.build folder and subfolders inside that in all cases. Without this , and including these fixes, Travis would actually build things twice as reported in #504. This is also one of the action points of #591.

I'm not sure why the diff shows that the whole Makefile is changed. But I guess that someone commited the wrong line endings at some points. 