### PR TITLE
Fixed compiling errors and updated keymaps for infinity_chibios

### DIFF
--- a/keyboards/infinity_chibios/config.h
+++ b/keyboards/infinity_chibios/config.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#define PREVENT_STUCK_MODIFIERS
 
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0xFEED
@@ -50,7 +51,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
 )
 
-/* Keymap for Infiity prototype */
+/* Keymap for Infinity prototype */
 #define INFINITY_PROTOTYPE
 
 

--- a/keyboards/infinity_chibios/config.h
+++ b/keyboards/infinity_chibios/config.h
@@ -52,8 +52,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 )
 
 /* Keymap for Infinity prototype */
-#define INFINITY_PROTOTYPE
+//#define INFINITY_PROTOTYPE
 
+/* Keymap for Infinity 1.1a (first revision with LED support) */
+//#define INFINITY_LED
 
 /*
  * Feature disable options

--- a/keyboards/infinity_chibios/infinity_chibios.h
+++ b/keyboards/infinity_chibios/infinity_chibios.h
@@ -29,15 +29,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     K54, K64, K74, K84, K05, K15, K25, K35, K45, K55, K65, K75, K85, \
     K06, K16, K26,           K36,                K46, K56, K66, K76 \
 ) { \
-    { KC_##K00, KC_##K01, KC_##K02, KC_##K03, KC_##K04, KC_##K05, KC_##K06 }, \
-    { KC_##K10, KC_##K11, KC_##K12, KC_##K13, KC_##K14, KC_##K15, KC_##K16 }, \
-    { KC_##K20, KC_##K21, KC_##K22, KC_##K23, KC_##K24, KC_##K25, KC_##K26 }, \
-    { KC_##K30, KC_##K31, KC_##K32, KC_##K33, KC_##K34, KC_##K35, KC_##K36 }, \
-    { KC_##K40, KC_##K41, KC_##K42, KC_##K43, KC_##K44, KC_##K45, KC_##K46 }, \
-    { KC_##K50, KC_##K51, KC_##K52, KC_##K53, KC_##K54, KC_##K55, KC_##K56 }, \
-    { KC_##K60, KC_##K61, KC_##K62, KC_##K63, KC_##K64, KC_##K65, KC_##K66 }, \
-    { KC_##K70, KC_##K71, KC_##K72, KC_##K73, KC_##K74, KC_##K75, KC_##K76 }, \
-    { KC_##K80, KC_##K81, KC_##K82, KC_##K83, KC_##K84, KC_##K85, KC_##K86 }  \
+    { K00, K01, K02, K03, K04, K05, K06 }, \
+    { K10, K11, K12, K13, K14, K15, K16 }, \
+    { K20, K21, K22, K23, K24, K25, K26 }, \
+    { K30, K31, K32, K33, K34, K35, K36 }, \
+    { K40, K41, K42, K43, K44, K45, K46 }, \
+    { K50, K51, K52, K53, K54, K55, K56 }, \
+    { K60, K61, K62, K63, K64, K65, K66 }, \
+    { K70, K71, K72, K73, K74, K75, K76 }, \
+    { K80, K81, K82, K83, K84, K85, K86 }  \
 }
 
 #else
@@ -50,15 +50,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     K64, K74, K84, K05, K15, K25, K35, K45, K55, K65, K75, K85, K06, \
     K16, K26, K36,           K46,                K56, K66, K76, K86 \
 ) { \
-    { KC_##K00, KC_##K01, KC_##K02, KC_##K03, KC_##K04, KC_##K05, KC_##K06 }, \
-    { KC_##K10, KC_##K11, KC_##K12, KC_##K13, KC_##K14, KC_##K15, KC_##K16 }, \
-    { KC_##K20, KC_##K21, KC_##K22, KC_##K23, KC_##K24, KC_##K25, KC_##K26 }, \
-    { KC_##K30, KC_##K31, KC_##K32, KC_##K33, KC_##K34, KC_##K35, KC_##K36 }, \
-    { KC_##K40, KC_##K41, KC_##K42, KC_##K43, KC_##K44, KC_##K45, KC_##K46 }, \
-    { KC_##K50, KC_##K51, KC_##K52, KC_##K53, KC_##K54, KC_##K55, KC_##K56 }, \
-    { KC_##K60, KC_##K61, KC_##K62, KC_##K63, KC_##K64, KC_##K65, KC_##K66 }, \
-    { KC_##K70, KC_##K71, KC_##K72, KC_##K73, KC_##K74, KC_##K75, KC_##K76 }, \
-    { KC_##K80, KC_##K81, KC_##K82, KC_##K83, KC_##K84, KC_##K85, KC_##K86 }  \
+    { K00, K01, K02, K03, K04, K05, K06 }, \
+    { K10, K11, K12, K13, K14, K15, K16 }, \
+    { K20, K21, K22, K23, K24, K25, K26 }, \
+    { K30, K31, K32, K33, K34, K35, K36 }, \
+    { K40, K41, K42, K43, K44, K45, K46 }, \
+    { K50, K51, K52, K53, K54, K55, K56 }, \
+    { K60, K61, K62, K63, K64, K65, K66 }, \
+    { K70, K71, K72, K73, K74, K75, K76 }, \
+    { K80, K81, K82, K83, K84, K85, K86 }  \
 }
 
 #endif

--- a/keyboards/infinity_chibios/keymaps/default/keymap.c
+++ b/keyboards/infinity_chibios/keymaps/default/keymap.c
@@ -14,12 +14,12 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * |     |Gui|Alt  |         Space         |Alt  |Gui|   |     |
      * `-----------------------------------------------------------'
      */
-    [0] =
-    KEYMAP(ESC, 1,   2,   3,   4,   5,   6,   7,   8,   9,   0,   MINS,EQL, BSLS, GRV, \
-           TAB, Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P,   LBRC,RBRC,BSPC, \
-           LCTL,A,   S,   D,   F,   G,   H,   J,   K,   L,   SCLN,QUOT,ENT,  \
-           LSFT,Z,   X,   C,   V,   B,   N,   M,   COMM,DOT, SLSH,RSFT,FN0, \
-           NO,  LGUI,LALT,          SPC,                RALT,RGUI,NO, NO),
+    [0] = KEYMAP(
+      KC_ESC, KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,   KC_MINS,KC_EQL, KC_BSLS, KC_GRV, \
+      KC_TAB, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,   KC_LBRC,KC_RBRC,KC_BSPC, \
+      KC_LCTL,KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,KC_QUOT,KC_ENT,  \
+      KC_LSFT,KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,KC_RSFT,MO(1), \
+      KC_NO,  KC_LGUI,KC_LALT,          KC_SPC,                KC_RALT,KC_RGUI,KC_NO, KC_NO),
 
     /* Layer 1: HHKB mode (HHKB Fn)
      * ,-----------------------------------------------------------.
@@ -34,15 +34,15 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * |     |Gui|Alt  |         Space         |Alt  |Gui|   |     |
      * `-----------------------------------------------------------'
      */ 
-    [1] = 
-    KEYMAP(PWR, F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12, INS, DEL,   \
-           CAPS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,PSCR,SLCK,PAUS, UP, TRNS, BSPC,      \
-           TRNS,VOLD,VOLU,MUTE,TRNS,TRNS,PAST,PSLS,HOME,PGUP,LEFT,RGHT,PENT,            \
-           TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,PPLS,PMNS,END, PGDN,DOWN,TRNS,TRNS,            \
-           TRNS,TRNS,TRNS,          TRNS,               TRNS,TRNS,TRNS,TRNS),
+    [1] = KEYMAP(
+      KC_PWR, KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10, KC_F11, KC_F12, KC_INS, KC_DEL,   \
+      KC_CAPS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_PSCR,KC_SLCK,KC_PAUS, KC_UP, KC_TRNS, KC_BSPC,      \
+      KC_TRNS,KC_VOLD,KC_VOLU,KC_MUTE,KC_TRNS,KC_TRNS,KC_PAST,KC_PSLS,KC_HOME,KC_PGUP,KC_LEFT,KC_RGHT,KC_PENT,            \
+      KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_PPLS,KC_PMNS,KC_END, KC_PGDN,KC_DOWN,KC_TRNS,KC_TRNS,            \
+      KC_TRNS,KC_TRNS,KC_TRNS,          KC_TRNS,               KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS),
 };
 
 const uint16_t fn_actions[] = {
-    [0] = ACTION_LAYER_MOMENTARY(1),
+    
 };
 

--- a/keyboards/infinity_chibios/keymaps/depariel/keymap.c
+++ b/keyboards/infinity_chibios/keymaps/depariel/keymap.c
@@ -1,0 +1,82 @@
+#include "infinity_chibios.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Layer 0: Default Layer
+     * ,-----------------------------------------------------------.
+     * |Esc|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|  \|  `|
+     * |-----------------------------------------------------------|
+     * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]| Bksp|
+     * |-----------------------------------------------------------|
+     * |Contro|  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Enter   |
+     * |-----------------------------------------------------------|
+     * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift |Fn2|
+     * |-----------------------------------------------------------'
+     * |Fn2 |Gui |Alt |         Space           |RAlt|Prv|PlPs|Next|
+     * `-----------------------------------------------------------'
+     */
+    [0] = KEYMAP(
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,            KC_BSLS,  KC_GRV, \
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,           KC_BSPC, \
+        KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, LT(5, KC_ENT),  \
+        KC_LSPO, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSPC, MO(4), \
+        MO(4),   KC_LGUI, KC_LALT,               LT(3, KC_SPC),                 KC_RALT, KC_MPRV, KC_MPLY, KC_MNXT),
+
+    /* Layer 1: "Toggle" off SpaceFn for League of Legends
+     */
+    [1] = KEYMAP(
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS,  KC_GRV, \
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSPC, \
+        KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  \
+        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, MO(4), \
+        MO(4),   KC_LGUI, KC_LALT,                   KC_SPC,                    KC_RALT, KC_MPRV, KC_MPLY, KC_MNXT),
+           
+    /* Layer 2: "Toggle" off SpaceFn for MapleRoyals
+     */
+    [2] = KEYMAP(
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS,  KC_GRV, \
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSPC, \
+        KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  \
+        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_UP,   KC_LSFT, \
+        MO(4),   KC_LGUI, KC_LALT,                   KC_SPC,                    KC_RALT, KC_LEFT, KC_DOWN, KC_RGHT),
+
+    /* Layer 3: FN layer 1
+     */ 
+    [3] = KEYMAP(
+        KC_NO,           KC_F1,   KC_F2,   KC_F3,   KC_F4,          KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NO,   KC_NO,   \
+        KC_NO,           KC_BTN1, KC_MS_U, KC_BTN2, LALT(KC_F4),    KC_HOME, KC_PGUP, KC_PSCR, KC_SLCK, KC_UP,   KC_NO,   KC_LPRN, KC_RPRN, KC_DEL,      \
+        MO(6),           KC_MS_L, KC_MS_D, KC_MS_R, KC_NO,          KC_END,  KC_PGDN, KC_TILD, KC_LEFT, KC_DOWN, KC_RGHT, KC_NO,   KC_NO,           \
+        LGUI(KC_SPC),    KC_NO,   KC_NO,   KC_NO,   KC_NO,          KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_CALC, KC_MENU, KC_TRNS, TG(4),           \
+        KC_TRNS,         KC_TRNS, KC_TRNS,                       LT(3, KC_SPC),                KC_TRNS, KC_VOLD, KC_MUTE, KC_VOLU),
+    
+    /* Layer 4: FN layer 2
+     */ 
+    [4] = KEYMAP(
+        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_PMNS, KC_PPLS, KC_PSLS, TG(2),   \
+        KC_CAPS, KC_NO,   KC_UP,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_PSCR, KC_NO,   KC_P7,   KC_P8,   KC_P9,   KC_PAST, KC_BSPC,      \
+        KC_LCTL, KC_LEFT, KC_DOWN, KC_RGHT, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_P4,   KC_P5,   KC_P6,   KC_PENT,           \
+        KC_LSFT, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_P1,   KC_P2,   KC_P3,   KC_RSFT, MO(4),           \
+        KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                   KC_P0,   KC_PDOT, KC_NO,   TG(1)),
+    
+    /* Layer 5: FN layer 3
+     */ 
+    [5] = KEYMAP(
+        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,            KC_NO,   KC_NO,   \
+        KC_TAB , KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_F13,  KC_F14,  KC_F15,  KC_F16,  KC_NO,            KC_TRNS,      \
+        KC_TRNS, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_F17,  KC_F18,  KC_F19,  KC_F20,  LT(5, KC_ENT),           \
+        KC_TRNS, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_F21,  KC_F22,  KC_F23,  KC_F24,  KC_TRNS, KC_TRNS,           \
+        KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                   KC_RALT, KC_NO,   KC_NO,  KC_NO),
+    
+    /* Layer 6: FN layer 4
+     */ 
+    [6] = KEYMAP(
+        KC_NO,                 KC_NO,            KC_NO,          KC_NO,            KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   \
+        LCTL(LSFT(KC_TAB)),    KC_NO,            LGUI(KC_UP),    KC_NO,            KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,      \
+        MO(6),                 LGUI(KC_LEFT),    LGUI(KC_DOWN),  LGUI(KC_RGHT),    KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,       \
+        KC_TRNS,               KC_NO,            KC_NO,          KC_NO,            KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_TRNS, KC_TRNS,           \
+        KC_TRNS,               KC_TRNS,          KC_TRNS,                   KC_TRNS,                 KC_TRNS, KC_NO,   KC_NO,   KC_NO),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+

--- a/keyboards/infinity_chibios/keymaps/hasu/keymap.c
+++ b/keyboards/infinity_chibios/keymaps/hasu/keymap.c
@@ -14,12 +14,12 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * |     |Gui|Alt  |         Space         |Alt  |Gui|   |     |
      * `-----------------------------------------------------------'
      */
-    [0] =
-    KEYMAP(ESC, 1,   2,   3,   4,   5,   6,   7,   8,   9,   0,   MINS,EQL, BSLS,GRV, \
-           TAB, Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P,   LBRC,RBRC,BSPC, \
-           LCTL,A,   S,   D,   F,   G,   H,   J,   K,   L,   FN3, QUOT,FN6, \
-           FN7, Z,   X,   C,   V,   B,   N,   M,   COMM,DOT, FN2, RSFT,FN1, \
-           NO,  LGUI,LALT,          FN4,                FN5, RGUI,NO, NO),
+    [0] = KEYMAP(
+        KC_ESC,    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,           KC_MINS,KC_EQL, KC_BSLS,KC_GRV, \
+        KC_TAB,    KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,           KC_LBRC,KC_RBRC,KC_BSPC, \
+        KC_LCTL,   KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   LT(3, KC_SCLN), KC_QUOT,MT(KC_RCTL, KC_ENT), \
+        OSM(LSFT), KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, LT(2, KC_SLSH), KC_RSFT,TG(1), \
+        KC_NO,     KC_LGUI,KC_LALT,         LT(4, KC_SPC),                 MO(4),  KC_RGUI,KC_NO,          KC_NO),
 
     /* Layer 1: HHKB mode (HHKB Fn)
      * ,-----------------------------------------------------------.
@@ -34,12 +34,12 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * |     |Gui|Alt  |         Space         |Alt  |Gui|   |     |
      * `-----------------------------------------------------------'
      */ 
-    [1] = 
-    KEYMAP(PWR, F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12, INS, DEL, \
-           CAPS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,PSCR,SLCK,PAUS, UP,  TRNS,BSPC, \
-           LCTL,VOLD,VOLU,MUTE,TRNS,TRNS,PAST,PSLS,HOME,PGUP,LEFT,RGHT,ENT, \
-           LSFT,TRNS,TRNS,TRNS,TRNS,TRNS,PPLS,PMNS,END, PGDN,DOWN,RSFT,TRNS, \
-           TRNS,LGUI,LALT,          TRNS,               RALT,RGUI,TRNS,TRNS),
+    [1] = KEYMAP(
+        KC_PWR, KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10, KC_F11, KC_F12, KC_INS, KC_DEL, \
+        KC_CAPS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_PSCR,KC_SLCK,KC_PAUS, KC_UP,  KC_TRNS,KC_BSPC, \
+        KC_LCTL,KC_VOLD,KC_VOLU,KC_MUTE,KC_TRNS,KC_TRNS,KC_PAST,KC_PSLS,KC_HOME,KC_PGUP,KC_LEFT,KC_RGHT,KC_ENT, \
+        KC_LSFT,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_PPLS,KC_PMNS,KC_END, KC_PGDN,KC_DOWN,KC_RSFT,KC_TRNS, \
+        KC_TRNS,KC_LGUI,KC_LALT,          KC_TRNS,                      KC_RALT,KC_RGUI,KC_TRNS,KC_TRNS),
 
     /* Layer 2: Vi mode[Slash]
      * ,-----------------------------------------------------------.
@@ -54,12 +54,12 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      *       |Gui|Alt  |          Space        |Alt  |Gui|
      *       `-------------------------------------------'
      */
-    [2] = \
-    KEYMAP(GRV, F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12, INS, DEL, \
-           TAB, HOME,PGDN,UP,  PGUP,END, HOME,PGDN,PGUP,END, NO,  NO,  NO,  BSPC, \
-           LCTL,NO,  LEFT,DOWN,RGHT,NO,  LEFT,DOWN,UP,  RGHT,NO,  NO,  ENT, \
-           LSFT,NO,  NO,  NO,  NO,  NO,  HOME,PGDN,PGUP,END, FN2, RSFT,TRNS, \
-           TRNS,LGUI,LALT,          SPC,                RALT,RGUI,TRNS,TRNS),
+    [2] = KEYMAP(
+        KC_GRV, KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10,         KC_F11, KC_F12, KC_INS, KC_DEL, \
+        KC_TAB, KC_HOME,KC_PGDN,KC_UP,  KC_PGUP,KC_END, KC_HOME,KC_PGDN,KC_PGUP,KC_END, KC_NO,          KC_NO,  KC_NO,  KC_BSPC, \
+        KC_LCTL,KC_NO,  KC_LEFT,KC_DOWN,KC_RGHT,KC_NO,  KC_LEFT,KC_DOWN,KC_UP,  KC_RGHT,KC_NO,          KC_NO,  KC_ENT, \
+        KC_LSFT,KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_HOME,KC_PGDN,KC_PGUP,KC_END, LT(2, KC_SLSH), KC_RSFT,KC_TRNS, \
+        KC_TRNS,KC_LGUI,KC_LALT,          KC_SPC,                       KC_RALT,KC_RGUI,KC_TRNS,        KC_TRNS),
 
     /* Layer 3: Mouse mode(IJKL)[Semicolon]
      * ,-----------------------------------------------------------.
@@ -75,12 +75,12 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      *      `--------------------------------------------'
      * Mc: Mouse Cursor / Mb: Mouse Button / Mw: Mouse Wheel
      */
-    [3] = \
-    KEYMAP(GRV, F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12, INS, DEL, \
-           FN8, NO,  NO,  NO,  NO,  NO,  WH_L,WH_D,MS_U,WH_U,WH_R,FN9, FN10,FN8, \
-           LCTL,ACL0,ACL1,ACL2,ACL2,NO,  NO,  MS_L,MS_D,MS_R,FN3, NO,  ENT, \
-           LSFT,NO,  NO,  NO,  NO,  BTN3,BTN2,BTN1,FN9, FN10,NO,  RSFT,TRNS, \
-           TRNS,LGUI,LALT,          BTN1,               TRNS,TRNS,TRNS,TRNS),
+    [3] = KEYMAP(
+        KC_GRV,       KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,          KC_F9,          KC_F10,         KC_F11,         KC_F12,        KC_INS, KC_DEL, \
+        LALT(KC_TAB), KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_WH_L,KC_WH_D,KC_MS_U,        KC_WH_U,        KC_WH_R,        ALT_T(KC_LEFT), ALT_T(KC_RGHT),LALT(KC_TAB), \
+        KC_LCTL,      KC_ACL0,KC_ACL1,KC_ACL2,KC_ACL2,KC_NO,  KC_NO,  KC_MS_L,KC_MS_D,        KC_MS_R,        LT(3, KC_SCLN), KC_NO,          KC_ENT, \
+        KC_LSFT,      KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_BTN3,KC_BTN2,KC_BTN1,ALT_T(KC_LEFT), ALT_T(KC_RGHT), KC_NO,          KC_RSFT,        KC_TRNS, \
+        KC_TRNS,      KC_LGUI,KC_LALT,          KC_BTN1,                      KC_TRNS,        KC_TRNS,        KC_TRNS,        KC_TRNS),
 
     /* Layer 4: Mouse mode(IJKL)[Space]
      * ,-----------------------------------------------------------.
@@ -96,104 +96,18 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      *      `--------------------------------------------'
      * Mc: Mouse Cursor / Mb: Mouse Button / Mw: Mouse Wheel
      */
-    [4] = \
-    KEYMAP(GRV, F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12, INS, DEL, \
-           FN8, NO,  NO,  NO,  NO,  NO,  WH_L,WH_D,MS_U,WH_U,WH_R,BTN4,BTN5,FN8, \
-           LCTL,VOLD,VOLU,MUTE,NO,  NO,  NO,  MS_L,MS_D,MS_R,BTN1,NO,  ENT, \
-           LSFT,NO,  NO,  NO,  NO,  BTN3,BTN2,BTN1,FN9, FN10,NO,  RSFT,TRNS, \
-           TRNS,LGUI,LALT,          TRNS,               TRNS,TRNS,TRNS,TRNS),
+    [4] = KEYMAP(
+        KC_GRV,       KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,         KC_F9,         KC_F10, KC_F11, KC_F12, KC_INS,       KC_DEL, \
+        LALT(KC_TAB), KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_WH_L,KC_WH_D,KC_MS_U,       KC_WH_U,       KC_WH_R,KC_BTN4,KC_BTN5,LALT(KC_TAB), \
+        KC_LCTL,      KC_VOLD,KC_VOLU,KC_MUTE,KC_NO,  KC_NO,  KC_NO,  KC_MS_L,KC_MS_D,       KC_MS_R,       KC_BTN1,KC_NO,  KC_ENT, \
+        KC_LSFT,      KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_BTN3,KC_BTN2,KC_BTN1,ALT_T(KC_LEFT),ALT_T(KC_RGHT),KC_NO,  KC_RSFT,KC_TRNS, \
+        KC_TRNS,      KC_LGUI,KC_LALT,          KC_TRNS,                      KC_TRNS,       KC_TRNS,       KC_TRNS,KC_TRNS),
 
-};
-
-/* id for user defined functions */
-enum function_id {
-    LSHIFT_LPAREN,
-};
-
-enum macro_id {
-    HELLO,
-    VOLUP,
-    ALT_TAB,
 };
 
 /*
  * Fn action definition
  */
 const uint16_t fn_actions[] = {
-    [0] = ACTION_DEFAULT_LAYER_SET(0),                // Default layer(not used)
-    [1] = ACTION_LAYER_TAP_TOGGLE(1),                 // HHKB layer(toggle with 5 taps)
-    [2] = ACTION_LAYER_TAP_KEY(2, KC_SLASH),          // Cursor layer with Slash*
-    [3] = ACTION_LAYER_TAP_KEY(3, KC_SCLN),           // Mousekey layer with Semicolon*
-    [4] = ACTION_LAYER_TAP_KEY(4, KC_SPC),            // Mousekey layer with Space
-    [5] = ACTION_LAYER_MOMENTARY(4),                  // Mousekey layer(IJKL)
-    [6] = ACTION_MODS_TAP_KEY(MOD_RCTL, KC_ENT),      // RControl with tap Enter
-    [7] = ACTION_MODS_ONESHOT(MOD_LSFT),              // Oneshot Shift
-    [8] = ACTION_MACRO(ALT_TAB),                      // Application switching
-    [9] = ACTION_MODS_KEY(MOD_LALT, KC_LEFT),
-   [10] = ACTION_MODS_KEY(MOD_LALT, KC_RIGHT),
+
 };
-
-/*
- * Macro definition
- */
-const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-    switch (id) {
-        case HELLO:
-            return (record->event.pressed ?
-                    MACRO( I(0), T(H), T(E), T(L), T(L), W(255), T(O), END ) :
-                    MACRO_NONE );
-        case VOLUP:
-            return (record->event.pressed ?
-                    MACRO( D(VOLU), U(VOLU), END ) :
-                    MACRO_NONE );
-        case ALT_TAB:
-            return (record->event.pressed ?
-                    MACRO( D(LALT), D(TAB), END ) :
-                    MACRO( U(TAB), END ));
-    }
-    return MACRO_NONE;
-}
-
-
-
-/*
- * user defined action function
- */
-void action_function(keyrecord_t *record, uint8_t id, uint8_t opt)
-{
-    if (record->event.pressed) dprint("P"); else dprint("R");
-    dprintf("%d", record->tap.count);
-    if (record->tap.interrupted) dprint("i");
-    dprint("\n");
-
-    switch (id) {
-        case LSHIFT_LPAREN:
-            // Shift parentheses example: LShft + tap '('
-            // http://stevelosh.com/blog/2012/10/a-modern-space-cadet/#shift-parentheses
-            // http://geekhack.org/index.php?topic=41989.msg1304899#msg1304899
-            if (record->event.pressed) {
-                if (record->tap.count > 0 && !record->tap.interrupted) {
-                    if (record->tap.interrupted) {
-                        dprint("tap interrupted\n");
-                        register_mods(MOD_BIT(KC_LSHIFT));
-                    }
-                } else {
-                    register_mods(MOD_BIT(KC_LSHIFT));
-                }
-            } else {
-                if (record->tap.count > 0 && !(record->tap.interrupted)) {
-                    add_weak_mods(MOD_BIT(KC_LSHIFT));
-                    send_keyboard_report();
-                    register_code(KC_9);
-                    unregister_code(KC_9);
-                    del_weak_mods(MOD_BIT(KC_LSHIFT));
-                    send_keyboard_report();
-                    record->tap.count = 0;  // ad hoc: cancel tap
-                } else {
-                    unregister_mods(MOD_BIT(KC_LSHIFT));
-                }
-            }
-            break;
-    }
-}

--- a/keyboards/infinity_chibios/keymaps/hasu/keymap.c
+++ b/keyboards/infinity_chibios/keymaps/hasu/keymap.c
@@ -18,7 +18,7 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_ESC,    KC_1,   KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,           KC_MINS,KC_EQL, KC_BSLS,KC_GRV, \
         KC_TAB,    KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,           KC_LBRC,KC_RBRC,KC_BSPC, \
         KC_LCTL,   KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,   KC_L,   LT(3, KC_SCLN), KC_QUOT,MT(KC_RCTL, KC_ENT), \
-        OSM(LSFT), KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, LT(2, KC_SLSH), KC_RSFT,TG(1), \
+        OSM(MOD_LSFT), KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, LT(2, KC_SLSH), KC_RSFT,TG(1), \
         KC_NO,     KC_LGUI,KC_LALT,         LT(4, KC_SPC),                 MO(4),  KC_RGUI,KC_NO,          KC_NO),
 
     /* Layer 1: HHKB mode (HHKB Fn)

--- a/keyboards/infinity_chibios/matrix.c
+++ b/keyboards/infinity_chibios/matrix.c
@@ -12,9 +12,12 @@
  * Infinity Pinusage:
  * Column pins are input with internal pull-down. Row pins are output and strobe with high.
  * Key is high or 1 when it turns on.
- *
+ *  INFINITY PRODUCTION (NO LED)
  *     col: { PTD1, PTD2, PTD3, PTD4, PTD5, PTD6, PTD7 }
  *     row: { PTB0, PTB1, PTB2, PTB3, PTB16, PTB17, PTC4, PTC5, PTD0 }
+ *  INFINITY PRODUCTION (WITH LED)
+ *     col: { PTD1, PTD2, PTD3, PTD4, PTD5, PTD6, PTD7 }
+ *     row: { PTC0, PTC1, PTC2, PTC3, PTC4, PTC5, PTC6, PTC7, PTD0 }
  */
 /* matrix state(1:on, 0:off) */
 static matrix_row_t matrix[MATRIX_ROWS];
@@ -34,6 +37,18 @@ void matrix_init(void)
     palSetPadMode(GPIOD, 6,  PAL_MODE_INPUT_PULLDOWN);
     palSetPadMode(GPIOD, 7,  PAL_MODE_INPUT_PULLDOWN);
 
+#ifdef INFINITY_LED
+    /* Row(strobe) */
+    palSetPadMode(GPIOC, 0,  PAL_MODE_OUTPUT_PUSHPULL);
+    palSetPadMode(GPIOC, 1,  PAL_MODE_OUTPUT_PUSHPULL);
+    palSetPadMode(GPIOC, 2,  PAL_MODE_OUTPUT_PUSHPULL);
+    palSetPadMode(GPIOC, 3,  PAL_MODE_OUTPUT_PUSHPULL);
+    palSetPadMode(GPIOC, 4,  PAL_MODE_OUTPUT_PUSHPULL);
+    palSetPadMode(GPIOC, 5,  PAL_MODE_OUTPUT_PUSHPULL);
+    palSetPadMode(GPIOC, 6,  PAL_MODE_OUTPUT_PUSHPULL);
+    palSetPadMode(GPIOC, 7,  PAL_MODE_OUTPUT_PUSHPULL);
+    palSetPadMode(GPIOD, 0,  PAL_MODE_OUTPUT_PUSHPULL);
+#else
     /* Row(strobe) */
     palSetPadMode(GPIOB, 0,  PAL_MODE_OUTPUT_PUSHPULL);
     palSetPadMode(GPIOB, 1,  PAL_MODE_OUTPUT_PUSHPULL);
@@ -44,7 +59,7 @@ void matrix_init(void)
     palSetPadMode(GPIOC, 4,  PAL_MODE_OUTPUT_PUSHPULL);
     palSetPadMode(GPIOC, 5,  PAL_MODE_OUTPUT_PUSHPULL);
     palSetPadMode(GPIOD, 0,  PAL_MODE_OUTPUT_PUSHPULL);
-
+#endif
     memset(matrix, 0, MATRIX_ROWS);
     memset(matrix_debouncing, 0, MATRIX_ROWS);
 }
@@ -53,7 +68,20 @@ uint8_t matrix_scan(void)
 {
     for (int row = 0; row < MATRIX_ROWS; row++) {
         matrix_row_t data = 0;
-
+    #ifdef INFINITY_LED
+        // strobe row
+        switch (row) {
+            case 0: palSetPad(GPIOC, 0);    break;
+            case 1: palSetPad(GPIOC, 1);    break;
+            case 2: palSetPad(GPIOC, 2);    break;
+            case 3: palSetPad(GPIOC, 3);    break;
+            case 4: palSetPad(GPIOC, 4);    break;
+            case 5: palSetPad(GPIOC, 5);    break;
+            case 6: palSetPad(GPIOC, 6);    break;
+            case 7: palSetPad(GPIOC, 7);    break;
+            case 8: palSetPad(GPIOD, 0);    break;
+        }
+    #else
         // strobe row
         switch (row) {
             case 0: palSetPad(GPIOB, 0);    break;
@@ -66,12 +94,26 @@ uint8_t matrix_scan(void)
             case 7: palSetPad(GPIOC, 5);    break;
             case 8: palSetPad(GPIOD, 0);    break;
         }
+    #endif
 
         wait_us(1); // need wait to settle pin state
 
         // read col data
         data = (palReadPort(GPIOD)>>1);
-
+    #ifdef INFINITY_LED
+        // un-strobe row
+        switch (row) {
+            case 0: palClearPad(GPIOC, 0);    break;
+            case 1: palClearPad(GPIOC, 1);    break;
+            case 2: palClearPad(GPIOC, 2);    break;
+            case 3: palClearPad(GPIOC, 3);    break;
+            case 4: palClearPad(GPIOC, 4);    break;
+            case 5: palClearPad(GPIOC, 5);    break;
+            case 6: palClearPad(GPIOC, 6);    break;
+            case 7: palClearPad(GPIOC, 7);    break;
+            case 8: palClearPad(GPIOD, 0);    break;
+        }
+    #else
         // un-strobe row
         switch (row) {
             case 0: palClearPad(GPIOB, 0);    break;
@@ -84,6 +126,7 @@ uint8_t matrix_scan(void)
             case 7: palClearPad(GPIOC, 5);    break;
             case 8: palClearPad(GPIOD, 0);    break;
         }
+    #endif
 
         if (matrix_debouncing[row] != data) {
             matrix_debouncing[row] = data;


### PR DESCRIPTION
* Fixed `infinity_chibios.h` errors that prevented functions from being used (`KC_` was prefixed to everything)
* Updated keymaps (and added my own) to be compatible with new `infinity_chibios.h`
* Fixed a typo in `config.h` and added `#define PREVENT_STUCK_MODIFIERS`

Fixes some issues from https://github.com/jackhumbert/qmk_firmware/issues/575

* Added matrix support for the latest Infinity 60% board
* No LED support for latest Infinity 60% board yet

Basically added https://github.com/tmk/tmk_keyboard/pull/371 to QMK