### PR TITLE
process_unicode: Fix set_unicode_input_mode()

### DIFF
--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -13,7 +13,7 @@ uint16_t hex_to_keycode(uint8_t hex)
   }
 }
 
-void set_unicode_mode(uint8_t os_target)
+void set_unicode_input_mode(uint8_t os_target)
 {
   input_mode = os_target;
 }


### PR DESCRIPTION
In the header, this was defined as `set_unicode_input_mode`, but the implementation had `set_unicode_mode` for a name. Changed the implementation to match the header.