### PR TITLE
Symbolic Unicode Input System

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,11 @@ ifeq ($(strip $(AUDIO_ENABLE)), yes)
 	SRC += $(QUANTUM_DIR)/audio/luts.c
 endif
 
+ifeq ($(strip $(UCIS_ENABLE)), yes)
+	OPT_DEFS += -DUCIS_ENABLE
+	UNICODE_ENABLE = yes
+endif
+
 ifeq ($(strip $(UNICODE_ENABLE)), yes)
     OPT_DEFS += -DUNICODE_ENABLE
 	SRC += $(QUANTUM_DIR)/process_keycode/process_unicode.c

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -107,7 +107,7 @@ void qk_ucis_symbol_fallback (void) {
   }
 }
 
-bool process_record_ucis (uint16_t keycode, keyrecord_t *record) {
+bool process_ucis (uint16_t keycode, keyrecord_t *record) {
   uint8_t i;
 
   if (!qk_ucis_state.in_progress)

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -18,40 +18,54 @@ void set_unicode_input_mode(uint8_t os_target)
   input_mode = os_target;
 }
 
+void unicode_input_start (void) {
+  switch(input_mode) {
+  case UC_OSX:
+    register_code(KC_LALT);
+    break;
+  case UC_LNX:
+    register_code(KC_LCTL);
+    register_code(KC_LSFT);
+    register_code(KC_U);
+    unregister_code(KC_U);
+    unregister_code(KC_LSFT);
+    unregister_code(KC_LCTL);
+    break;
+  case UC_WIN:
+    register_code(KC_LALT);
+    register_code(KC_PPLS);
+    unregister_code(KC_PPLS);
+    break;
+  }
+}
+
+void unicode_input_finish (void) {
+  switch(input_mode) {
+  case UC_OSX:
+  case UC_WIN:
+    unregister_code(KC_LALT);
+    break;
+  case UC_LNX:
+    register_code(KC_SPC);
+    unregister_code(KC_SPC);
+    break;
+  }
+}
+
+void register_hex(uint16_t hex) {
+  for(int i = 3; i >= 0; i--) {
+    uint8_t digit = ((hex >> (i*4)) & 0xF);
+    register_code(hex_to_keycode(digit));
+    unregister_code(hex_to_keycode(digit));
+  }
+}
+
 bool process_unicode(uint16_t keycode, keyrecord_t *record) {
   if (keycode > QK_UNICODE && record->event.pressed) {
     uint16_t unicode = keycode & 0x7FFF;
-    switch(input_mode) {
-      case UC_OSX:
-        register_code(KC_LALT);
-        break;
-      case UC_LNX:
-        register_code(KC_LCTL);
-        register_code(KC_LSFT);
-        register_code(KC_U);
-        unregister_code(KC_U);
-        break;
-      case UC_WIN:
-        register_code(KC_LALT);
-        register_code(KC_PPLS);
-        unregister_code(KC_PPLS);
-        break;
-    }
-    for(int i = 3; i >= 0; i--) {
-        uint8_t digit = ((unicode >> (i*4)) & 0xF);
-        register_code(hex_to_keycode(digit));
-        unregister_code(hex_to_keycode(digit));
-    }
-    switch(input_mode) {
-      case UC_OSX:
-      case UC_WIN:
-        unregister_code(KC_LALT);
-        break;
-      case UC_LNX:
-        unregister_code(KC_LCTL);
-        unregister_code(KC_LSFT);
-        break;
-    }
+    unicode_input_start();
+    register_hex(unicode);
+    unicode_input_finish();
   }
   return true;
 }

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -60,6 +60,14 @@ void register_hex(uint16_t hex) {
   }
 }
 
+void register_hex32(uint32_t hex) {
+  for(int i = 7; i >= 0; i--) {
+    uint8_t digit = ((hex >> (i*8)) & 0xF);
+    register_code(hex_to_keycode(digit));
+    unregister_code(hex_to_keycode(digit));
+  }
+}
+
 bool process_unicode(uint16_t keycode, keyrecord_t *record) {
   if (keycode > QK_UNICODE && record->event.pressed) {
     uint16_t unicode = keycode & 0x7FFF;
@@ -156,9 +164,7 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
     for (i = 0; ucis_symbol_table[i].symbol; i++) {
       if (is_uni_seq (ucis_symbol_table[i].symbol)) {
         symbol_found = true;
-        for (uint8_t j = 0; ucis_symbol_table[i].codes[j]; j++) {
-          register_hex(ucis_symbol_table[i].codes[j]);
-        }
+        register_hex32(ucis_symbol_table[i].code);
         break;
       }
     }

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -110,7 +110,15 @@ void qk_ucis_symbol_fallback (void) {
 bool process_record_ucis (uint16_t keycode, keyrecord_t *record) {
   uint8_t i;
 
-  if (!qk_ucis_state.in_progress || !record->event.pressed)
+  if (!qk_ucis_state.in_progress)
+    return true;
+
+  if (qk_ucis_state.count >= UCIS_MAX_SYMBOL_LENGTH &&
+      !(keycode == KC_BSPC || keycode == KC_ESC || keycode == KC_SPC || keycode == KC_ENT)) {
+    return false;
+  }
+
+  if (!record->event.pressed)
     return true;
 
   qk_ucis_state.codes[qk_ucis_state.count] = keycode;

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -37,6 +37,7 @@ void unicode_input_start (void) {
     unregister_code(KC_PPLS);
     break;
   }
+  wait_ms(UNICODE_TYPE_DELAY);
 }
 
 void unicode_input_finish (void) {
@@ -109,6 +110,7 @@ void qk_ucis_symbol_fallback (void) {
     uint8_t code = qk_ucis_state.codes[i];
     register_code(code);
     unregister_code(code);
+    wait_ms(UNICODE_TYPE_DELAY);
   }
 }
 
@@ -135,6 +137,7 @@ void register_ucis(const char *hex) {
     if (kc) {
       register_code (kc);
       unregister_code (kc);
+      wait_ms (UNICODE_TYPE_DELAY);
     }
   }
 }
@@ -172,6 +175,7 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
     for (i = qk_ucis_state.count; i > 0; i--) {
       register_code (KC_BSPC);
       unregister_code (KC_BSPC);
+      wait_ms(UNICODE_TYPE_DELAY);
     }
 
     if (keycode == KC_ESC) {

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -75,6 +75,11 @@ void qk_ucis_start(void) {
   qk_ucis_state.count = 0;
   qk_ucis_state.in_progress = true;
 
+  qk_ucis_start_user();
+}
+
+__attribute__((weak))
+void qk_ucis_start_user(void) {
   unicode_input_start();
   register_hex(0x2328);
   unicode_input_finish();

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -60,14 +60,6 @@ void register_hex(uint16_t hex) {
   }
 }
 
-void register_hex32(uint32_t hex) {
-  for(int i = 7; i >= 0; i--) {
-    uint8_t digit = ((hex >> (i*8)) & 0xF);
-    register_code(hex_to_keycode(digit));
-    unregister_code(hex_to_keycode(digit));
-  }
-}
-
 bool process_unicode(uint16_t keycode, keyrecord_t *record) {
   if (keycode > QK_UNICODE && record->event.pressed) {
     uint16_t unicode = keycode & 0x7FFF;
@@ -120,6 +112,33 @@ void qk_ucis_symbol_fallback (void) {
   }
 }
 
+void register_ucis(const char *hex) {
+  for(int i = 0; hex[i]; i++) {
+    uint8_t kc = 0;
+    char c = hex[i];
+
+    switch (c) {
+    case '0':
+      kc = KC_0;
+      break;
+    case '1' ... '9':
+      kc = c - '1' + KC_1;
+      break;
+    case 'a' ... 'f':
+      kc = c - 'a' + KC_A;
+      break;
+    case 'A' ... 'F':
+      kc = c - 'A' + KC_A;
+      break;
+    }
+
+    if (kc) {
+      register_code (kc);
+      unregister_code (kc);
+    }
+  }
+}
+
 bool process_ucis (uint16_t keycode, keyrecord_t *record) {
   uint8_t i;
 
@@ -164,7 +183,7 @@ bool process_ucis (uint16_t keycode, keyrecord_t *record) {
     for (i = 0; ucis_symbol_table[i].symbol; i++) {
       if (is_uni_seq (ucis_symbol_table[i].symbol)) {
         symbol_found = true;
-        register_hex32(ucis_symbol_table[i].code);
+        register_ucis(ucis_symbol_table[i].code + 2);
         break;
       }
     }

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -15,6 +15,33 @@ void register_hex(uint16_t hex);
 
 bool process_unicode(uint16_t keycode, keyrecord_t *record);
 
+#ifdef UCIS_ENABLE
+#ifndef UCIS_MAX_SYMBOL_LENGTH
+#define UCIS_MAX_SYMBOL_LENGTH 32
+#endif
+
+typedef struct {
+  char *symbol;
+  uint16_t codes[4];
+} qk_ucis_symbol_t;
+
+struct {
+  uint8_t count;
+  uint16_t codes[UCIS_MAX_SYMBOL_LENGTH];
+  bool in_progress:1;
+} qk_ucis_state;
+
+#define UCIS_TABLE(...) {__VA_ARGS__, {NULL, {}}}
+#define UCIS_SYM(name, ...) {name, {__VA_ARGS__, 0}}
+
+extern const qk_ucis_symbol_t ucis_symbol_table[];
+
+void qk_ucis_start(void);
+void qk_ucis_symbol_fallback (void);
+bool process_record_ucis (uint16_t keycode, keyrecord_t *record);
+
+#endif
+
 #define UC_BSPC	UC(0x0008)
 
 #define UC_SPC	UC(0x0020)

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -9,6 +9,9 @@
 #define UC_BSD 3
 
 void set_unicode_input_mode(uint8_t os_target);
+void unicode_input_start(void);
+void unicode_input_finish(void);
+void register_hex(uint16_t hex);
 
 bool process_unicode(uint16_t keycode, keyrecord_t *record);
 

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -8,6 +8,10 @@
 #define UC_WIN 2
 #define UC_BSD 3
 
+#ifndef UNICODE_TYPE_DELAY
+#define UNICODE_TYPE_DELAY 10
+#endif
+
 void set_unicode_input_mode(uint8_t os_target);
 void unicode_input_start(void);
 void unicode_input_finish(void);

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -38,7 +38,7 @@ extern const qk_ucis_symbol_t ucis_symbol_table[];
 
 void qk_ucis_start(void);
 void qk_ucis_symbol_fallback (void);
-bool process_record_ucis (uint16_t keycode, keyrecord_t *record);
+bool process_ucis (uint16_t keycode, keyrecord_t *record);
 
 #endif
 

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -37,6 +37,7 @@ struct {
 extern const qk_ucis_symbol_t ucis_symbol_table[];
 
 void qk_ucis_start(void);
+void qk_ucis_start_user(void);
 void qk_ucis_symbol_fallback (void);
 bool process_ucis (uint16_t keycode, keyrecord_t *record);
 

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -12,7 +12,6 @@ void set_unicode_input_mode(uint8_t os_target);
 void unicode_input_start(void);
 void unicode_input_finish(void);
 void register_hex(uint16_t hex);
-void register_hex32(uint32_t hex);
 
 bool process_unicode(uint16_t keycode, keyrecord_t *record);
 
@@ -23,7 +22,7 @@ bool process_unicode(uint16_t keycode, keyrecord_t *record);
 
 typedef struct {
   char *symbol;
-  uint32_t code;
+  char *code;
 } qk_ucis_symbol_t;
 
 struct {
@@ -32,14 +31,15 @@ struct {
   bool in_progress:1;
 } qk_ucis_state;
 
-#define UCIS_TABLE(...) {__VA_ARGS__, {NULL, 0}}
-#define UCIS_SYM(name, code) {name, code}
+#define UCIS_TABLE(...) {__VA_ARGS__, {NULL, NULL}}
+#define UCIS_SYM(name, code) {name, #code}
 
 extern const qk_ucis_symbol_t ucis_symbol_table[];
 
 void qk_ucis_start(void);
 void qk_ucis_start_user(void);
 void qk_ucis_symbol_fallback (void);
+void register_ucis(const char *hex);
 bool process_ucis (uint16_t keycode, keyrecord_t *record);
 
 #endif

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -12,6 +12,7 @@ void set_unicode_input_mode(uint8_t os_target);
 void unicode_input_start(void);
 void unicode_input_finish(void);
 void register_hex(uint16_t hex);
+void register_hex32(uint32_t hex);
 
 bool process_unicode(uint16_t keycode, keyrecord_t *record);
 
@@ -22,7 +23,7 @@ bool process_unicode(uint16_t keycode, keyrecord_t *record);
 
 typedef struct {
   char *symbol;
-  uint16_t codes[4];
+  uint32_t code;
 } qk_ucis_symbol_t;
 
 struct {
@@ -31,8 +32,8 @@ struct {
   bool in_progress:1;
 } qk_ucis_state;
 
-#define UCIS_TABLE(...) {__VA_ARGS__, {NULL, {}}}
-#define UCIS_SYM(name, ...) {name, {__VA_ARGS__, 0}}
+#define UCIS_TABLE(...) {__VA_ARGS__, {NULL, 0}}
+#define UCIS_SYM(name, code) {name, code}
 
 extern const qk_ucis_symbol_t ucis_symbol_table[];
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -87,6 +87,9 @@ bool process_record_quantum(keyrecord_t *record) {
   #ifdef UNICODE_ENABLE
     process_unicode(keycode, record) &&
   #endif
+  #ifdef UCIS_ENABLE
+    process_ucis(keycode, record) &&
+  #endif
       true)) {
     return false;
   }


### PR DESCRIPTION
Purpose
======
The purpose of this feature is to allow the person in front of the keyboard to enter Unicode symbols by name. Once the keymap is modified to call `qk_ucis_start()', whenever that action is triggered, we will cache the next few chars (up to 32 by default), and if any of `Enter`, `Space` or `ESC` are pressed, we delete everything back. Unless `ESC` was pressed, we then look up the string entered so far, and compare it to a dictionary. If found, we enter the code associated with the string, otherwise we replay the keys. During the input process, backspace will delete the previous character (holding it likely doesn't work, mind you).

The feature is disabled by default, and should not increase the firmware size if left disabled. If enabled, it also enables unicode input.

Example
=======
So, to give a minimal example, here is how to use this feature:

* Add `UCIS_ENABLE = yes` to your keymaps `Makefile`.
* Create a macro, or a leader-key sequence or similar that will call `qk_ucis_start()`.
* Create a lookup table like this:

```c
const qk_ucis_symbol_t ucis_symbol_table[] = UCIS_TABLE
(
 UCIS_SYM("poop", 0x1f4a9),
 UCIS_SYM("rofl", 0x1f923),
 UCIS_SYM("kiss", 0x1f619),
 UCIS_SYM("snowman", 0x2603),
 UCIS_SYM("coffee", 0x2615),
 UCIS_SYM("heart", 0x2764)
);
```

Recompile the firmware, and press your trigger combo, and type `snowman`, followed by `Enter` or `Space`. If all goes well, the text you entered should be replaced by the snowman symbol.

![tty](https://cloud.githubusercontent.com/assets/17243/17662004/db49d58c-62e2-11e6-81e6-85a40b9850f2.gif)

Known issues
==========

I have only tested this on Linux, it may or may not work elsewhere. Replaying keycodes is not the best implementation, as it can only replay the 8bit keycodes. This was easy to implement, but its not a 100% accurate playback. In most cases, that should not be a problem, I believe.

I've been using this for the past 3 days, and the latest variant for a couple of hours, and so far I did not manage to break it yet. At least not in ways I wasn't expecting.