### PR TITLE
tap-dance: Include action_tapping.h for TAPPING_TERM

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -1,4 +1,5 @@
 #include "quantum.h"
+#include "action_tapping.h"
 
 static qk_tap_dance_state_t qk_tap_dance_state;
 bool td_debug_enable = false;


### PR DESCRIPTION
Include `action_tapping.h`, so the keymap does not have to define a `TAPPING_TERM` for us, and we can use the default.
