### PR TITLE
Add a register/unregister_code16 pair of functions

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -8,9 +8,9 @@ void qk_tap_dance_pair_finished (qk_tap_dance_state_t *state, void *user_data) {
   qk_tap_dance_pair_t *pair = (qk_tap_dance_pair_t *)user_data;
 
   if (state->count == 1) {
-    register_code (pair->kc1);
+    register_code16 (pair->kc1);
   } else if (state->count == 2) {
-    register_code (pair->kc2);
+    register_code16 (pair->kc2);
   }
 }
 
@@ -18,9 +18,9 @@ void qk_tap_dance_pair_reset (qk_tap_dance_state_t *state, void *user_data) {
   qk_tap_dance_pair_t *pair = (qk_tap_dance_pair_t *)user_data;
 
   if (state->count == 1) {
-    unregister_code (pair->kc1);
+    unregister_code16 (pair->kc1);
   } else if (state->count == 2) {
-    unregister_code (pair->kc2);
+    unregister_code16 (pair->kc2);
   }
 }
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -1,5 +1,42 @@
 #include "quantum.h"
 
+static void do_code16 (uint16_t code, void (*f) (uint8_t)) {
+  switch (code) {
+  case QK_MODS ... QK_MODS_MAX:
+    break;
+  default:
+    return;
+  }
+
+  if (code & QK_LCTL)
+    f(KC_LCTL);
+  if (code & QK_LSFT)
+    f(KC_LSFT);
+  if (code & QK_LALT)
+    f(KC_LALT);
+  if (code & QK_LGUI)
+    f(KC_LGUI);
+
+  if (code & QK_RCTL)
+    f(KC_RCTL);
+  if (code & QK_RSFT)
+    f(KC_RSFT);
+  if (code & QK_RALT)
+    f(KC_RALT);
+  if (code & QK_RGUI)
+    f(KC_RGUI);
+}
+
+void register_code16 (uint16_t code) {
+  do_code16 (code, register_code);
+  register_code (code);
+}
+
+void unregister_code16 (uint16_t code) {
+  unregister_code (code);
+  do_code16 (code, unregister_code);
+}
+
 __attribute__ ((weak))
 bool process_action_kb(keyrecord_t *record) {
   return true;

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -83,6 +83,9 @@ void reset_keyboard(void);
 void startup_user(void);
 void shutdown_user(void);
 
+void register_code16 (uint16_t code);
+void unregister_code16 (uint16_t code);
+
 #ifdef BACKLIGHT_ENABLE
 void backlight_init_ports(void);
 


### PR DESCRIPTION
These functions register not only the 8bit keycode, but the modifiers too. It doesn't handle the full range of the upper 8bits, just the mods, but that's a good start.

Changed the tap-dance pair functions to use these, so one can do:

  `ACTION_TAP_DANCE_DOUBLE (KC_COLN, KC_SCLN)`

...and that will do the right thing.

This makes quite a few things not only possible, but much easier too, at the cost of about 250 bytes, which may be optimized further down later.