### PR TITLE
quantum: Move qk_ucis_state to process_unicode.c

### DIFF
--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -74,6 +74,8 @@ bool process_unicode(uint16_t keycode, keyrecord_t *record) {
 }
 
 #ifdef UCIS_ENABLE
+qk_ucis_state_t qk_ucis_state;
+
 void qk_ucis_start(void) {
   qk_ucis_state.count = 0;
   qk_ucis_state.in_progress = true;

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -29,11 +29,13 @@ typedef struct {
   char *code;
 } qk_ucis_symbol_t;
 
-struct {
+typedef struct {
   uint8_t count;
   uint16_t codes[UCIS_MAX_SYMBOL_LENGTH];
   bool in_progress:1;
-} qk_ucis_state;
+} qk_ucis_state_t;
+
+extern qk_ucis_state_t qk_ucis_state;
 
 #define UCIS_TABLE(...) {__VA_ARGS__, {NULL, NULL}}
 #define UCIS_SYM(name, code) {name, #code}


### PR DESCRIPTION
In order to not declare the same variable in multiple objects (which happens when building UCIS-enabled keymap for both the ErgoDox EZ and the ErgoDox Infinity), move the declaration to the .c file, and keep only an extern reference in the header.

Many thanks to @fredizzimo for spotting the error in Travis, and suggesting the fix.
