### PR TITLE
build_keyboard.mk: Restore UCIS_ENABLE support

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -148,6 +148,11 @@ ifeq ($(strip $(AUDIO_ENABLE)), yes)
 	SRC += $(QUANTUM_DIR)/audio/luts.c
 endif
 
+ifeq ($(strip $(UCIS_ENABLE)), yes)
+	OPT_DEFS += -DUCIS_ENABLE
+	UNICODE_ENABLE = yes
+endif
+
 ifeq ($(strip $(UNICODE_ENABLE)), yes)
     OPT_DEFS += -DUNICODE_ENABLE
 	SRC += $(QUANTUM_DIR)/process_keycode/process_unicode.c


### PR DESCRIPTION
During the build system refactor, support for enabling UCIS seems to have been lost. This little patch adds that back, so that keymaps using UCIS can be compiled again.