### PR TITLE
process_unicode: Add get_unicode_input_mode()

### DIFF
--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -18,6 +18,10 @@ void set_unicode_input_mode(uint8_t os_target)
   input_mode = os_target;
 }
 
+uint8_t get_unicode_input_mode(void) {
+  return input_mode;
+}
+
 __attribute__((weak))
 void unicode_input_start (void) {
   switch(input_mode) {

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -13,6 +13,7 @@
 #endif
 
 void set_unicode_input_mode(uint8_t os_target);
+uint8_t get_unicode_input_mode(void);
 void unicode_input_start(void);
 void unicode_input_finish(void);
 void register_hex(uint16_t hex);


### PR DESCRIPTION
There may be cases where one would like to know the current Unicode input mode, without having to keep track of it themselves. Add a function that does just this.