### PR TITLE
tap-dance: Do not start a sequence on keyup

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -65,9 +65,9 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
       highest_td = idx;
     action = &tap_dance_actions[idx];
 
-    action->state.keycode = keycode;
     action->state.pressed = record->event.pressed;
     if (record->event.pressed) {
+      action->state.keycode = keycode;
       action->state.count++;
       action->state.timer = timer_read();
 
@@ -77,8 +77,9 @@ bool process_tap_dance(uint16_t keycode, keyrecord_t *record) {
         process_tap_dance_action_on_dance_finished (paction);
         reset_tap_dance (&paction->state);
       }
+
+      last_td = keycode;
     }
-    last_td = keycode;
 
     break;
 


### PR DESCRIPTION
There was an odd case, which confused the hell out of tap-dance: suppose you had a number of tap-dance keys, on a layer, and as part of the tap-dance, you turned that layer off - or had it on one-shot to begin with. In this case, the keydown event would trigger the tap-dance key, but the keyup would not. This had two funky consequences:

- tap-dance did not correctly register that the dance has ended.
- pressing any other tap-dance key would interrupt the previous tap-dance, and potentially input unwanted characters.

To fix this, we simply do not start a tap-dance sequence on keyup, only when it is pressed. This way the previous sequence has enough time to time-out and finish properly, and we don't get confused.

This fixes algernon/ergodox-layout#107.