### PR TITLE
Add support for JD40 MKII PCB

### DIFF
--- a/keyboards/jd40/Makefile
+++ b/keyboards/jd40/Makefile
@@ -1,0 +1,74 @@
+
+
+# MCU name
+#MCU = at90usb1287
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Boot Section Size in *bytes*
+#   Teensy halfKay   512
+#   Teensy++ halfKay 1024
+#   Atmel DFU loader 4096
+#   LUFA bootloader  4096
+#   USBaspLoader     2048
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE ?= yes		# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE ?= yes		# Mouse keys(+4700)
+EXTRAKEY_ENABLE ?= yes		# Audio control and System control(+450)
+# CONSOLE_ENABLE ?= yes		# Console for debug(+400)
+# COMMAND_ENABLE ?= yes		# Commands for debug and configuration
+KEYBOARD_LOCK_ENABLE ?= yes	# Allow locking of keyboard via magic key
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+# SLEEP_LED_ENABLE ?= yes	# Breathing sleep LED during USB suspend
+NKRO_ENABLE ?= yes			# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+# BACKLIGHT_ENABLE ?= yes	# Enable keyboard backlight functionality
+# MIDI_ENABLE ?= YES			# MIDI controls
+# UNICODE_ENABLE ?= YES		# Unicode
+# BLUETOOTH_ENABLE ?= yes	# Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE ?= yes          # Enable RGB Underglow
+
+ifndef QUANTUM_DIR
+	include ../../Makefile
+endif
+

--- a/keyboards/jd40/config.h
+++ b/keyboards/jd40/config.h
@@ -1,0 +1,79 @@
+/*
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID    0xFEED
+#define PRODUCT_ID   0x6060
+#define DEVICE_VER   0x0001
+#define MANUFACTURER    geekhack
+#define PRODUCT         jd40v2
+#define DESCRIPTION     t.m.k. keyboard firmware for JD40 MKII
+
+/* key matrix size */
+#define MATRIX_ROWS 4
+#define MATRIX_COLS 12
+
+/*
+ * Keyboard Matrix Assignments
+ *
+ * Change this to how you wired your keyboard
+ * COLS: AVR pins used for columns, left to right
+ * ROWS: AVR pins used for rows, top to bottom
+ * DIODE_DIRECTION: COL2ROW = COL = Anode (+), ROW = Cathode (-, marked on diode)
+ *         ROW2COL = ROW = Anode (+), COL = Cathode (-, marked on diode)
+ *
+*/
+#define MATRIX_ROW_PINS { F0, F1, F5, B4 }
+#define MATRIX_COL_PINS { F4, D7, B5, B6, C6, C7, D4, D6, D5, D0, D1, D2 }
+#define UNUSED_PINS
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION COL2ROW
+
+/* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
+#define DEBOUNCING_DELAY 5
+
+/* define if matrix has ghost (lacks anti-ghosting diodes) */
+//#define MATRIX_HAS_GHOST
+
+/* number of backlight levels */
+#define BACKLIGHT_LEVELS 3
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+
+/* key combination for magic key command */
+#define IS_COMMAND() ( \
+  keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+)
+
+#define RGB_DI_PIN D3
+#define RGBLIGHT_TIMER
+#define RGBLED_NUM 12         // Number of LEDs
+#define RGBLIGHT_HUE_STEP 8
+#define RGBLIGHT_SAT_STEP 8
+#define RGBLIGHT_VAL_STEP 8
+
+#endif

--- a/keyboards/jd40/jd40.c
+++ b/keyboards/jd40/jd40.c
@@ -1,0 +1,26 @@
+#include "jd40.h"
+
+void led_set_kb(uint8_t usb_led) {
+	// put your keyboard LED indicator (ex: Caps Lock LED) toggling code here
+	
+
+  //  if (usb_led & (1<<USB_LED_CAPS_LOCK)) {
+	//	gh60_caps_led_on();
+	//	} else {
+	//	gh60_caps_led_off(); 
+  //  }
+	
+    // if (usb_led & (1<<USB_LED_NUM_LOCK)) {
+		// gh60_esc_led_on();
+		// } else {
+		// gh60_esc_led_off(); 
+    // }
+	
+    // if (usb_led & (1<<USB_LED_SCROLL_LOCK)) {
+		// gh60_fn_led_on();
+		// } else {
+		// gh60_fn_led_off(); 	
+    // }
+
+	led_set_user(usb_led);	
+}

--- a/keyboards/jd40/jd40.h
+++ b/keyboards/jd40/jd40.h
@@ -1,0 +1,45 @@
+#ifndef JD40_H
+#define JD40_H
+
+#include "quantum.h"
+#include "led.h"
+
+/* GH60 LEDs 
+ *   GPIO pads
+ *   0 F7 WASD LEDs
+ *   1 F6 ESC LED
+ *   2 F5 FN LED
+ *   3 F4 POKER Arrow LEDs
+ *   B2 Capslock LED
+ *   B0 not connected
+ */
+ 
+ /*
+inline void gh60_caps_led_on(void)      { DDRB |=  (1<<2); PORTB &= ~(1<<2); }
+inline void gh60_poker_leds_on(void)    { DDRF |=  (1<<4); PORTF &= ~(1<<4); }
+inline void gh60_fn_led_on(void)    	{ DDRF |=  (1<<5); PORTF &= ~(1<<5); }
+inline void gh60_esc_led_on(void)    	{ DDRF |=  (1<<6); PORTF &= ~(1<<6); }
+inline void gh60_wasd_leds_on(void)    	{ DDRF |=  (1<<7); PORTF &= ~(1<<7); }
+
+inline void gh60_caps_led_off(void)     { DDRB &= ~(1<<2); PORTB &= ~(1<<2); }
+inline void gh60_poker_leds_off(void)   { DDRF &= ~(1<<4); PORTF &= ~(1<<4); }
+inline void gh60_fn_led_off(void)   	{ DDRF &= ~(1<<5); PORTF &= ~(1<<5); }
+inline void gh60_esc_led_off(void)   	{ DDRF &= ~(1<<6); PORTF &= ~(1<<6); }
+inline void gh60_wasd_leds_off(void)   	{ DDRF &= ~(1<<7); PORTF &= ~(1<<7); }
+*/
+
+/* JD40 MKII keymap definition macro
+ */
+#define KEYMAP( \
+    K01, K02, K03, K04, K05, K06, K07, K08, K09, K10, K11, K12, \
+	K13, K14, K15, K16, K17, K18, K19, K20, K21, K22, K23, \
+	K24, K25, K26, K27, K28, K29, K30, K31, K32, K33, K34, \
+	K35, K36, K37, K38, K39, K40, K41, K42, K43, K44 \
+) { \
+    { KC_##K01, KC_##K02, KC_##K03, KC_##K04, KC_##K05, KC_##K06, KC_##K07, KC_##K08, KC_##K09, KC_##K10, KC_##K11, KC_##K12 }, \
+    { KC_##K13, KC_##K14, KC_##K15, KC_##K16, KC_##K17, KC_##K18, KC_##K19, KC_##K20, KC_##K21, KC_##K22, KC_##K23, KC_NO    }, \
+    { KC_##K24, KC_##K25, KC_##K26, KC_##K27, KC_##K28, KC_##K29, KC_##K30, KC_##K31, KC_##K32, KC_##K33, KC_##K34, KC_NO    }, \
+    { KC_##K35, KC_##K36, KC_##K37, KC_##K38, KC_##K39, KC_NO,    KC_##K40, KC_##K41, KC_##K42, KC_##K43, KC_##K44, KC_NO    }  \
+}
+
+#endif

--- a/keyboards/jd40/keymaps/default/keymap.c
+++ b/keyboards/jd40/keymaps/default/keymap.c
@@ -1,0 +1,164 @@
+#include "jd40.h"
+#include "action_layer.h"
+
+#define _BL 0
+#define _AL 1
+#define _FL 2
+#define _UL 3
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+	[_BL] = KEYMAP(
+  F12,  Q,    W,    E,    R,    T,    Y,    U,    I,    O,    P,   BSPC,
+  TAB,  A,    S,    D,    F,    G,    H,    J,    K,    L,    ENT,
+  LSFT, Z,    X,    C,    V,    B,    N,    M,    COMM, UP, DOT,
+  LCTL, LGUI, LALT, FN0,  SPC,  SPC,  FN0,  LEFT,  DOWN, RIGHT ),
+  
+	[_AL] = KEYMAP(
+  GRV,   F1,   F2,   F3,   F4,   F5,   F6,   F7,   F8,   F9,  F10,  DEL,
+  CAPS, 1,    2,    3,    4,    5,    6,    7,    8,    9,    0,
+  TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, SCLN, PGUP, QUOT,
+  TRNS, TRNS, TRNS, TRNS, FN3,  FN3,  TRNS, HOME, PGDN, END ),
+
+	[_FL] = KEYMAP(
+  TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,
+  TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,
+  TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,
+  TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS ),
+   
+	[_UL] = KEYMAP(
+  TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,
+  TRNS, FN4,  FN5,  FN11, FN10, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,
+  TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,
+  TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS ),
+};
+
+enum function_id {
+    RGBLED_TOGGLE,
+    RGBLED_STEP_MODE,
+    RGBLED_INCREASE_HUE,
+    RGBLED_DECREASE_HUE,
+    RGBLED_INCREASE_SAT,
+    RGBLED_DECREASE_SAT,
+    RGBLED_INCREASE_VAL,
+    RGBLED_DECREASE_VAL,
+    SHIFT_ESC, 
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    [0]  = ACTION_LAYER_MOMENTARY(1),  // Momentary Fn overlay
+    [1]  = ACTION_LAYER_TOGGLE(2),     // Toggle Arrow Layer overlay
+    [2]  = ACTION_LAYER_TAP_KEY(2, KC_CAPS), // Tap to toggle caps lock and hold to activate function layer
+    [3]  = ACTION_LAYER_TOGGLE(3),     // Toggle Underglow Layer overlay
+    [4]  = ACTION_FUNCTION(RGBLED_TOGGLE), //Turn on/off underglow
+    [5]  = ACTION_FUNCTION(RGBLED_STEP_MODE), // Change underglow mode
+    [6]  = ACTION_FUNCTION(RGBLED_INCREASE_HUE),
+    [7]  = ACTION_FUNCTION(RGBLED_DECREASE_HUE),
+    [8]  = ACTION_FUNCTION(RGBLED_INCREASE_SAT),
+    [9]  = ACTION_FUNCTION(RGBLED_DECREASE_SAT),
+    [10] = ACTION_FUNCTION(RGBLED_INCREASE_VAL),
+    [11] = ACTION_FUNCTION(RGBLED_DECREASE_VAL),
+    [12] = ACTION_FUNCTION(SHIFT_ESC),
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+  // MACRODOWN only works in this function 
+      switch(id) {
+        case 0:
+          if (record->event.pressed) {
+            register_code(KC_RSFT);
+          } else {
+            unregister_code(KC_RSFT);
+          }
+        break;
+      }
+    return MACRO_NONE;
+};
+
+void matrix_scan_user(void) {
+
+// Layer LED indicators
+// ESC led on when in function layer, WASD cluster leds enabled when on arrow cluster
+    uint32_t layer = layer_state;
+    if (layer & (1<<1)) {
+        //gh60_wasd_leds_on();
+    } else {
+        //gh60_wasd_leds_off();
+    }
+
+    if (layer & (1<<2)) {
+        //gh60_esc_led_on();
+    } else {
+        //gh60_esc_led_off();
+    }
+};
+
+#define MODS_CTRL_MASK  (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
+
+void action_function(keyrecord_t *record, uint8_t id, uint8_t opt) {
+  switch (id) {
+    case RGBLED_TOGGLE:
+      //led operations
+      if (record->event.pressed) {
+        rgblight_toggle();
+        }
+        break;
+    case RGBLED_INCREASE_HUE:
+      if (record->event.pressed) {
+        rgblight_increase_hue();
+        }
+        break;
+    case RGBLED_DECREASE_HUE:
+      if (record->event.pressed) {
+        rgblight_decrease_hue();
+        }
+        break;
+    case RGBLED_INCREASE_SAT:
+      if (record->event.pressed) {
+        rgblight_increase_sat();
+        }
+        break;
+    case RGBLED_DECREASE_SAT:
+      if (record->event.pressed) {
+        rgblight_decrease_sat();
+        }
+        break;
+    case RGBLED_INCREASE_VAL:
+        if (record->event.pressed) {
+          rgblight_increase_val();
+        }
+        break;
+    case RGBLED_DECREASE_VAL:
+        if (record->event.pressed) {
+          rgblight_decrease_val();
+        }
+        break;
+    case RGBLED_STEP_MODE:
+        if (record->event.pressed) {
+          rgblight_step();
+        }
+        break;
+    static uint8_t shift_esc_shift_mask;
+    // Shift + ESC = ~
+    case SHIFT_ESC:
+      shift_esc_shift_mask = get_mods()&MODS_CTRL_MASK;
+      if (record->event.pressed) {
+        if (shift_esc_shift_mask) {
+          add_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          add_key(KC_ESC);
+          send_keyboard_report();
+        }
+      } else {
+        if (shift_esc_shift_mask) {
+          del_key(KC_GRV);
+          send_keyboard_report();
+        } else {
+          del_key(KC_ESC);
+          send_keyboard_report();
+        }
+      }
+      break;
+    }
+};

--- a/keyboards/jd40/readme.md
+++ b/keyboards/jd40/readme.md
@@ -1,0 +1,17 @@
+## jd40 mkii keyboard firmware
+
+    Pins:
+    MATRIX_ROW_PINS { F0, F1, F5, B4 }
+    MATRIX_COL_PINS { F4, D7, B5, B6, C6, C7, D4, D6, D5, D0, D1, D2 }
+    RGB_DI_PIN D3	
+	
+======================
+
+## Quantum MK Firmware
+
+For the full Quantum feature list, see [the parent readme.md](/readme.md).
+
+## Building
+
+Download or clone the whole firmware and navigate to the keyboards/jd40 folder. 
+Once your dev env is setup, you'll be able to type `make` to generate your .hex - you can then use the Amtel Flip to program your .hex file. 

--- a/keyboards/jd40/rules.mk
+++ b/keyboards/jd40/rules.mk
@@ -1,0 +1,69 @@
+
+
+# MCU name
+#MCU = at90usb1287
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Boot Section Size in *bytes*
+#   Teensy halfKay   512
+#   Teensy++ halfKay 1024
+#   Atmel DFU loader 4096
+#   LUFA bootloader  4096
+#   USBaspLoader     2048
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE ?= yes		# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE ?= yes		# Mouse keys(+4700)
+EXTRAKEY_ENABLE ?= yes		# Audio control and System control(+450)
+# CONSOLE_ENABLE ?= yes		# Console for debug(+400)
+# COMMAND_ENABLE ?= yes		# Commands for debug and configuration
+KEYBOARD_LOCK_ENABLE ?= yes	# Allow locking of keyboard via magic key
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+# SLEEP_LED_ENABLE ?= yes	# Breathing sleep LED during USB suspend
+NKRO_ENABLE ?= yes			# USB Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+# BACKLIGHT_ENABLE ?= yes	# Enable keyboard backlight functionality
+# MIDI_ENABLE ?= YES			# MIDI controls
+# UNICODE_ENABLE ?= YES		# Unicode
+# BLUETOOTH_ENABLE ?= yes	# Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE ?= yes          # Enable RGB Underglow


### PR DESCRIPTION
This adds full support for the JD40 MKII PCB.
RGB support is enabled by default.