### PR TITLE
Change CTL_T(KC_ESC) to KC_LCTRL and update readme

### DIFF
--- a/keyboards/ergodox/keymaps/romanzolotarev-norman-osx/keymap.c
+++ b/keyboards/ergodox/keymaps/romanzolotarev-norman-osx/keymap.c
@@ -6,23 +6,23 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [BASE] = KEYMAP(
-    KC_GRV,        KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_F5,
-    KC_TAB,        KC_Q,    KC_W,    KC_D,    KC_F,    KC_K,    KC_BSLS,
-    CTL_T(KC_ESC), KC_A,    KC_S,    KC_E,    KC_T,    KC_G,
-    KC_LSFT,       KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_LBRC,
-    KC_F1,         KC_F2,   KC_F3,   KC_F4,   KC_LGUI, 
-    /*-*/          /*-*/    /*-*/    /*-*/    /*-*/    KC_VOLD, KC_MUTE,
-    /*-*/          /*-*/    /*-*/    /*-*/    /*-*/    /*-*/    KC_VOLU,
-    /*-*/          /*-*/    /*-*/    /*-*/    /*-*/    KC_BSPC, CTL_T(KC_ESC), KC_LALT,
+    KC_GRV,   KC_1,    KC_2,  KC_3,    KC_4,    KC_5,    KC_F5,
+    KC_TAB,   KC_Q,    KC_W,  KC_D,    KC_F,    KC_K,    KC_BSLS,
+    KC_LCTRL, KC_A,    KC_S,  KC_E,    KC_T,    KC_G,
+    KC_LSFT,  KC_Z,    KC_X,  KC_C,    KC_V,    KC_B,    KC_LBRC,
+    KC_F1,    KC_F2,   KC_F3, KC_F4,   KC_LGUI,
+    /*-*/     /*-*/    /*-*/  /*-*/    /*-*/    KC_VOLD, KC_MUTE,
+    /*-*/     /*-*/    /*-*/  /*-*/    /*-*/    /*-*/    KC_VOLU,
+    /*-*/     /*-*/    /*-*/  /*-*/    /*-*/    KC_BSPC, CTL_T(KC_ESC), KC_LALT,
     //
-    /*-*/          KC_F6,   KC_6,    KC_7,    KC_8,    KC_9,    KC_0,          KC_EQL,
-    /*-*/          KC_NO,   KC_J,    KC_U,    KC_R,    KC_L,    KC_SCLN,       KC_MINS,
-    /*-*/          /*-*/    KC_Y,    KC_N,    KC_I,    KC_O,    KC_H,          KC_ENT,
-    /*-*/          KC_RBRC, KC_P,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,       KC_RSFT,
-    /*-*/          /*-*/    /*-*/    KC_RGUI, KC_LEFT, KC_DOWN, KC_UP,         KC_RGHT, 
-    KC_MPLY,       KC_MNXT,
+    /*-*/     KC_F6,   KC_6,  KC_7,    KC_8,    KC_9,    KC_0,          KC_EQL,
+    /*-*/     KC_NO,   KC_J,  KC_U,    KC_R,    KC_L,    KC_SCLN,       KC_MINS,
+    /*-*/     /*-*/    KC_Y,  KC_N,    KC_I,    KC_O,    KC_H,          KC_ENT,
+    /*-*/     KC_RBRC, KC_P,  KC_M,    KC_COMM, KC_DOT,  KC_SLSH,       KC_RSFT,
+    /*-*/     /*-*/    /*-*/  KC_RGUI, KC_LEFT, KC_DOWN, KC_UP,         KC_RGHT,
+    KC_MPLY,  KC_MNXT,
     KC_MPRV,
-    KC_RALT,       KC_QUOT, KC_SPC
+    KC_RALT,  KC_QUOT, KC_SPC
     )
 };
 

--- a/keyboards/ergodox/keymaps/romanzolotarev-norman-osx/readme.md
+++ b/keyboards/ergodox/keymaps/romanzolotarev-norman-osx/readme.md
@@ -1,28 +1,41 @@
 # Roman's Layout
 
-There is only one layer based on [Norman layout](https://normanlayout.info/).
+There is only one layer, and it is  based on [Norman
+layout](https://normanlayout.info/).
 
 Looking for multiple-layer layouts?
 
-- [Symbols, arrows, plover, HJKL arrows](../romanzolotarev-norman-plover-osx-hjkl/)
+- [Symbols, arrows, plover, HJKL
+  arrows](../romanzolotarev-norman-plover-osx-hjkl/)
 - [Same with IJKL arrows](../romanzolotarev-norman-plover-osx/)
 
 [![keyboard-layout](romanzolotarev-norman-osx.png)](http://www.keyboard-layout-editor.com/#/gists/9e89d54f1ea6eeeb7dab1b2d19d28195)
 
-## Functional Keys
+## How to use Vim key
 
-- Tap `F1` to mute microphone via [Shush](http://mizage.com/shush/).
-- Tap `F2` to copy screenshot to the clipboard.
-- Hold `SHIFT` and tap `F2` to save screenshot as a file.
-- Tap `F3`, `F4`, `F5`, `F6` to resize a window via [Divvy](http://mizage.com/divvy/).
-
-## CTRL/ESC
-
-CTRL and ESC are frequently used in Vim.
+It is `CTL_T(KC_ESC)` and it works this way:
 
 - Tap `CTRL/ESC` to send `ESC`.
 - Hold `CTRL/ESC` to use as `CTRL`.
 
-## Activate N-rollover
+## How to activate N-rollover
 
 - Hold left `SHIFT` and right `SHIRT` and then tap `N`.
+
+## How to make and flash on OS X
+
+First you need to install few brew packages.
+
+```bash
+brew tap osx-cross/avr
+brew install dfu-programmer avr-libc teensy_loader_cli
+```
+
+Then you can clone this repository, make and flash your ErgoDox.
+
+```bash
+git clone https://github.com/romanzolotarev/qmk_firmware
+cd qmk_firmware/keyboards/ergodox
+# Optionally tweak ./keymaps/romanzolotarev-norman-osx/keymap.c
+SLEEP_LED_ENABLED=no KEYMAP=romanzolotarev-norman-osx make teensy
+```


### PR DESCRIPTION
### Changes

- Added setup, make and flash instruction to [readme.md](https://github.com/romanzolotarev/qmk_firmware/blob/master/keyboards/ergodox/keymaps/romanzolotarev-norman-osx/readme.md).
- Changed left CTRL key to plain KC_LCTRL.