### PR TITLE
Update Atreus default map

### DIFF
--- a/keyboards/atreus/config.h
+++ b/keyboards/atreus/config.h
@@ -37,7 +37,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // COLS: Left to right, ROWS: Top to bottom
 #if defined(ATREUS_ASTAR)
 #   define MATRIX_ROW_PINS { D0, D1, D3, D2 }
+#if defined(PCBDOWN)
+#   define MATRIX_COL_PINS { B7, D6, F7, F6, B6, D4, E6, B4, B5, C6, D7 }
+#else
 #   define MATRIX_COL_PINS { D7, C6, B5, B4, E6, D4, B6, F6, F7, D6, B7 }
+#endif
 #   define UNUSED_PINS
 #elif defined(ATREUS_TEENSY2)
 #   define MATRIX_ROW_PINS { D0, D1, D2, D3 }

--- a/keyboards/atreus/keymaps/classic/keymap.c
+++ b/keyboards/atreus/keymaps/classic/keymap.c
@@ -1,6 +1,3 @@
-// this is the style you want to emulate.
-// This is the canonical layout file for the Quantum project. If you want to add another keyboard,
-
 #include "atreus.h"
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
@@ -18,29 +15,17 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   {KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   KC_LALT,  KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH },
   {KC_ESC, KC_TAB, KC_LGUI,  KC_LSFT, KC_BSPC,  KC_LCTL, KC_SPC,  MO(_RS), KC_MINS, KC_QUOT, KC_ENT  }
 },
-/*
- *  !       @     up     {    }        ||     pgup    7     8     9    *
- *  #     left   down  right  $        ||     pgdn    4     5     6    +
- *  [       ]      (     )    &        ||       `     1     2     3    \
- * lower  insert super shift bksp ctrl || alt space   fn    .     0    =
- */
 [_RS] = { /* [> RAISE <] */
-  {KC_EXLM, KC_AT,   KC_UP,   KC_LCBR, KC_RCBR, KC_TRNS, KC_PGUP, KC_7,    KC_8,   KC_9, KC_ASTR},
-  {KC_HASH, KC_LEFT, KC_DOWN, KC_RGHT, KC_DLR,  KC_TRNS, KC_PGDN, KC_4,    KC_5,   KC_6, KC_PLUS},
-  {KC_LBRC, KC_RBRC, KC_LPRN, KC_RPRN, KC_AMPR, KC_LALT, KC_GRV,  KC_1,    KC_2,   KC_3, KC_BSLS},
+  {KC_EXLM, KC_AT,   KC_LCBR, KC_RCBR, KC_PIPE, KC_TRNS, KC_PGUP, KC_7,    KC_8,   KC_9, KC_ASTR},
+  {KC_HASH, KC_DLR,  KC_LPRN, KC_RPRN, KC_GRV,  KC_TRNS, KC_PGDN, KC_4,    KC_5,   KC_6, KC_PLUS},
+  {KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_TILD, KC_LALT, KC_AMPR, KC_1,    KC_2,   KC_3, KC_BSLS},
   {TG(_LW), KC_INS,  KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, KC_SPC,  KC_TRNS, KC_DOT, KC_0, KC_EQL}
 },
-/*
- * insert home   up  end   pgup       ||      up     F7    F8    F9   F10
- *  del   left  down right pgdn       ||     down    F4    F5    F6   F11
- *       volup             reset      ||             F1    F2    F3   F12
- *       voldn  super shift bksp ctrl || alt space   L0  prtsc scroll pause
- */
 [_LW] = { /* [> LOWER <] */
   {KC_INS,  KC_HOME, KC_UP,   KC_END,  KC_PGUP, KC_TRNS, KC_UP,   KC_F7,   KC_F8,   KC_F9,   KC_F10},
   {KC_DELT, KC_LEFT, KC_DOWN, KC_RGHT, KC_DOWN, KC_TRNS, KC_DOWN, KC_F4,   KC_F5,   KC_F6,   KC_F11},
-  {KC_TRNS, KC_VOLU, KC_TRNS, KC_TRNS, RESET,   KC_LALT, KC_TRNS, KC_F1,   KC_F2,   KC_F3,   KC_F12},
-  {KC_TRNS, KC_VOLD, KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, KC_SPC,  DF(_QW), KC_PSCR, KC_SLCK, KC_PAUS}
+  {KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_LALT, KC_TRNS, KC_F1,   KC_F2,   KC_F3,   KC_F12},
+  {KC_TRNS, KC_TRNS, KC_LGUI, KC_LSFT, KC_BSPC, KC_LCTL, KC_SPC,  DF(_QW), KC_TRNS, KC_TRNS, RESET}
 }};
 
 const uint16_t PROGMEM fn_actions[] = {

--- a/keyboards/atreus/rules.mk
+++ b/keyboards/atreus/rules.mk
@@ -2,11 +2,11 @@
 
 ifdef TEENSY2
     OPT_DEFS += -DATREUS_TEENSY2
-    ATRUES_UPLOAD_COMMAND = teensy_loader_cli -w -mmcu=$(MCU) $(TARGET).hex
+    ATREUS_UPLOAD_COMMAND = teensy_loader_cli -w -mmcu=$(MCU) $(TARGET).hex
 else
     OPT_DEFS += -DATREUS_ASTAR
     OPT_DEFS += -DCATERINA_BOOTLOADER
-    ATRUES_UPLOAD_COMMAND = while [ ! -r $(USB) ]; do sleep 1; done; \
+    ATREUS_UPLOAD_COMMAND = while [ ! -r $(USB) ]; do sleep 1; done; \
                             avrdude -p $(MCU) -c avr109 -U flash:w:$(TARGET).hex -P $(USB)
 endif
 
@@ -79,4 +79,4 @@ UNICODE_ENABLE ?= YES 		# Unicode
 USB ?= /dev/cu.usbmodem1411
 
 upload: build
-	$(ATRUES_UPLOAD_COMMAND)
+	$(ATREUS_UPLOAD_COMMAND)


### PR DESCRIPTION
The official Atreus firmware moved to this layout as default a few months ago. They kept the old default as "classic" so I did that here too.

I also fixed the "ATRUES" typo in config and added the PCBDOWN option (again, mirroring the official firmware).