### PR TITLE
util/install_dependecies.sh: fix yum packages

### DIFF
--- a/util/install_dependencies.sh
+++ b/util/install_dependencies.sh
@@ -68,9 +68,8 @@ elif [[ -n "$(type -P yum)" ]]; then
     avr-libc \
     dfu-programmer \
     dfu-util \
-    gcc-arm-none-eabi \
-    binutils-arm-none-eabi \
-    libnewlib-arm-none-eabi \
+    arm-none-eabi-gcc-cs \
+    arm-none-eabi-newlib \
     git \
     diffutils
   # The listed eabi pacackes do unfortunately not exist for CentOS,


### PR DESCRIPTION
Fix dependencies for Fedora/CentOS/RedHat - I believe it was a copy/paste error from https://github.com/jackhumbert/qmk_firmware/commit/c30aba0bce989d29458bd3b56090400cb0a91d03 - tested on Fedora 24 also.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>