### PR TITLE
Fix issue #772 Meh and Hyper not working

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -155,9 +155,10 @@ void process_action(keyrecord_t *record, action_t action)
                                                                 action.key.mods<<4;
                 if (event.pressed) {
                     if (mods) {
-                        if (IS_MOD(action.key.code)) {
+                        if (IS_MOD(action.key.code) || action.key.code == KC_NO) {
                             // e.g. LSFT(KC_LGUI): we don't want the LSFT to be weak as it would make it useless.
-                            // this also makes LSFT(KC_LGUI) behave exactly the same as LGUI(KC_LSFT)
+                            // This also makes LSFT(KC_LGUI) behave exactly the same as LGUI(KC_LSFT).
+                            // Same applies for some keys like KC_MEH which are declared as MEH(KC_NO).
                             add_mods(mods);
                         } else {
                             add_weak_mods(mods);
@@ -168,7 +169,7 @@ void process_action(keyrecord_t *record, action_t action)
                 } else {
                     unregister_code(action.key.code);
                     if (mods) {
-                        if (IS_MOD(action.key.code)) {
+                        if (IS_MOD(action.key.code) || action.key.code == KC_NO) {
                             del_mods(mods);
                         } else {
                             del_weak_mods(mods);


### PR DESCRIPTION
Keys defined as `LCTL(LSFT(KC_NO))` will now behave exactly the same as if they were defined as `LCTL(KC_LSFT)`. This is the case for `MEH`, `HYPR` and `LCAG` (see [keymap.h](https://github.com/jackhumbert/qmk_firmware/blob/0f205a854ff18967acef5a6060efb655b6b77247/quantum/keymap.h#L182-L193)):

```c
#define HYPR(kc) (kc | QK_LCTL | QK_LSFT | QK_LALT | QK_LGUI)
#define MEH(kc)  (kc | QK_LCTL | QK_LSFT | QK_LALT)
#define LCAG(kc) (kc | QK_LCTL | QK_LALT | QK_LGUI)
```
This fixes #772 as those keys used to have their mods set as `weak_mods`, which made them quite useless.

Actually, this change would even allow to redefine all modifier keys based on `KC_NO`, e.g.:
```c
#define KC_LCTRL LCTL(KC_NO)
```
which would free up keycodes `0xE0` - `0xE7` in [keycode.h](https://github.com/jackhumbert/qmk_firmware/blob/0f205a854ff18967acef5a6060efb655b6b77247/tmk_core/common/keycode.h#L385-L393).