### PR TITLE
Fix lets_split.c so that audio can be disabled

### DIFF
--- a/keyboards/lets_split/lets_split.c
+++ b/keyboards/lets_split/lets_split.c
@@ -24,7 +24,9 @@ void matrix_init_kb(void) {
 };
 
 void shutdown_user(void) {
-    PLAY_NOTE_ARRAY(tone_goodbye, false, 0);
-    _delay_ms(150);
-    stop_all_notes();
+    #ifdef AUDIO_ENABLE
+        PLAY_NOTE_ARRAY(tone_goodbye, false, 0);
+	_delay_ms(150);
+	stop_all_notes();
+    #endif
 }


### PR DESCRIPTION
Matching the use of `#ifdef AUDIO_ENABLE` used in `matrix_init_kb()` in order to compile firmware for the Let's Split keyboard without audio enabled.