### PR TITLE
Missing ifdef statement

### DIFF
--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -7,7 +7,9 @@ int midi_offset = 7;
 bool process_midi(uint16_t keycode, keyrecord_t *record) {
     if (keycode == MI_ON && record->event.pressed) {
       midi_activated = true;
+#ifdef AUDIO_ENABLE
       music_scale_user();
+#endif
       return false;
     }
 


### PR DESCRIPTION
I discovered this bug when I tried to compile my firmware. When audio is disabled and midi is enabled, the firmware fails to compile:
```
Linking: ../../../../.build/planck_rev4_default.elf                                                 [ERRORS]
 | 
 | ../../../../.build/obj_planck_rev4_default/quantum/process_keycode/process_midi.o: In function `process_midi':
 | /home/adam/projects/qmk_firmware/keyboards/planck/keymaps/default/../../../../quantum/process_keycode/process_midi.c:10: undefined reference to `music_scale_user'
 | collect2: error: ld returned 1 exit status
 | 
make: *** [../../../../tmk_core/rules.mk:384: ../../../../.build/planck_rev4_default.elf] Error 1
```
This is fixed by adding an `#ifdef AUDIO_ENABLE` surrounding the reference to `music_scale_user` in `process_midi.c`.
