### PR TITLE
Declare Unicode method hex_to_keycode() as “weak”

### DIFF
--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -2,6 +2,7 @@
 
 static uint8_t input_mode;
 
+__attribute__((weak))
 uint16_t hex_to_keycode(uint8_t hex)
 {
   if (hex == 0x0) {


### PR DESCRIPTION
Declare Unicode method hex_to_keycode() as “weak” to be able to override it in keymaps.

Similar to #672 this is necessary when using a different software keymap like [Neo](https://github.com/jackhumbert/qmk_firmware/issues/neo-layout.org). A keymap could then use something like this:
```
uint16_t hex_to_keycode(uint8_t hex)
{
  if (hex == 0x0) {
    return KC_0;
  } else if (hex < 0xA) {
    return KC_1 + (hex - 0x1);
  } else {
    switch(hex) {
      case 0xA:
        return NEO_A;
      case 0xB:
        return NEO_B;
      case 0xC:
        return NEO_C;
      case 0xD:
        return NEO_D;
      case 0xE:
        return NEO_E;
      case 0xF:
        return NEO_F;
    }
  }
}
```