### PR TITLE
Reduce the default dynamic macro buffer

### DIFF
--- a/quantum/dynamic_macro.h
+++ b/quantum/dynamic_macro.h
@@ -8,8 +8,13 @@
 /* May be overridden with a custom value. Be aware that the effective
  * macro length is half of this value: each keypress is recorded twice
  * because of the down-event and up-event. This is not a bug, it's the
- * intended behavior. */
-#define DYNAMIC_MACRO_SIZE 256
+ * intended behavior.
+ *
+ * Usually it should be fine to set the macro size to at least 256 but
+ * there have been reports of it being too much in some users' cases,
+ * so 128 is considered a safe default.
+ */
+#define DYNAMIC_MACRO_SIZE 128
 #endif
 
 /* DYNAMIC_MACRO_RANGE must be set as the last element of user's

--- a/readme.md
+++ b/readme.md
@@ -823,7 +823,7 @@ And then, to assign this macro to a key on your keyboard layout, you just use `M
 
 ## Dynamic macros: record and replay macros in runtime
 
-In addition to the static macros described above, you may enable the dynamic macros which you may record while writing. They are forgotten as soon as the keyboard is unplugged. Only two such macros may be stored at the same time, with the total length of 128 keypresses.
+In addition to the static macros described above, you may enable the dynamic macros which you may record while writing. They are forgotten as soon as the keyboard is unplugged. Only two such macros may be stored at the same time, with the total length of 64 keypresses (by default).
 
 To enable them, first add a new element to the `planck_keycodes` enum -- `DYNAMIC_MACRO_RANGE`:
 
@@ -864,7 +864,7 @@ Add the following code to the very beginning of your `process_record_user()` fun
 
 To start recording the macro, press either `DYN_REC_START1` or `DYN_REC_START2`. To finish the recording, press the `_DYN` layer button. The handler awaits specifically for the `MO(_DYN)` keycode as the "stop signal" so please don't use any fancy ways to access this layer, use the regular `MO()` modifier. To replay the macro, press either `DYN_MACRO_PLAY1` or `DYN_MACRO_PLAY2`.
 
-If the LED-s start blinking during the recording with each keypress, it means there is no more space for the macro in the macro buffer. To fit the macro in, either make the other macro shorter (they share the same buffer) or increase the buffer size by setting the `DYNAMIC_MACRO_SIZE` preprocessor macro (default value: 256; please read the comments for it in the header).
+If the LED-s start blinking during the recording with each keypress, it means there is no more space for the macro in the macro buffer. To fit the macro in, either make the other macro shorter (they share the same buffer) or increase the buffer size by setting the `DYNAMIC_MACRO_SIZE` preprocessor macro (default value: 128; please read the comments for it in the header).
 
 For the details about the internals of the dynamic macros, please read the comments in the `dynamic_macro.h` header.
 


### PR DESCRIPTION
There have been reports of it leaving not enough free memory preventing the keyboard from working properly.

See: #721 