### PR TITLE
Allow unicode up to 0xFFFFF using separate mapping table

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -153,6 +153,11 @@ ifeq ($(strip $(UCIS_ENABLE)), yes)
 	UNICODE_ENABLE = yes
 endif
 
+ifeq ($(strip $(UNICODEMAP_ENABLE)), yes)
+	OPT_DEFS += -DUNICODEMAP_ENABLE
+	UNICODE_ENABLE = yes
+endif
+
 ifeq ($(strip $(UNICODE_ENABLE)), yes)
     OPT_DEFS += -DUNICODE_ENABLE
 	SRC += $(QUANTUM_DIR)/process_keycode/process_unicode.c

--- a/keyboards/planck/keymaps/priyadi/Makefile
+++ b/keyboards/planck/keymaps/priyadi/Makefile
@@ -1,0 +1,26 @@
+
+
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in 
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE = no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = no        # Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes       # Audio control and System control(+450)
+CONSOLE_ENABLE = no         # Console for debug(+400)
+COMMAND_ENABLE = yes        # Commands for debug and configuration
+NKRO_ENABLE = yes            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
+MIDI_ENABLE = no            # MIDI controls
+AUDIO_ENABLE = yes           # Audio output on port C6
+UNICODE_ENABLE = no         # Unicode
+UNICODEMAP_ENABLE = yes     # Unicode map
+BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
+RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend
+
+ifndef QUANTUM_DIR
+	include ../../../../Makefile
+endif

--- a/keyboards/planck/keymaps/priyadi/keymap.c
+++ b/keyboards/planck/keymaps/priyadi/keymap.c
@@ -1,0 +1,417 @@
+// This is the canonical layout file for the Quantum project. If you want to add another keyboard,
+// this is the style you want to emulate.
+
+#include "planck.h"
+#include "action_layer.h"
+#ifdef AUDIO_ENABLE
+  #include "audio.h"
+#endif
+#include "eeconfig.h"
+#include "process_unicode.h"
+
+extern keymap_config_t keymap_config;
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _QWERTY 0
+#define _COLEMAK 1
+#define _WORKMAN 2
+#define _PUNC 9
+#define _NUM 10
+#define _FUNC 11
+#define _EMOJI 12
+#define _ADJUST 16
+
+enum planck_keycodes {
+  // layouts
+  QWERTY = SAFE_RANGE,
+  COLEMAK,
+  WORKMAN,
+
+  // layer switchers
+  PUNC,
+  NUM,
+  FUNC,
+  EMOJI,
+
+  // os switchers
+  LINUX,
+  WIN,
+  OSX,
+};
+
+// Fillers to make layering clearer
+#define _______ KC_TRNS
+#define XXXXXXX KC_NO
+
+// unicode map
+enum unicode_name {
+  GRIN, // grinning face 😊
+  TJOY, // tears of joy 😂
+  SMILE, // grining face with smiling eyes 😁
+  HEART, // heart ❤
+  EYERT, // smiling face with heart shaped eyes 😍
+  CRY, // crying face 😭
+  SMEYE, // smiling face with smiling eyes 😊
+  UNAMU, // unamused 😒
+  KISS, // kiss 😘
+  HART2, // two hearts 💕
+  WEARY, // weary 😩
+  OKHND, // ok hand sign 👌
+  PENSV, // pensive 😔
+  SMIRK, // smirk 😏
+  RECYC, // recycle ♻
+  WINK, // wink 😉
+  THMUP, // thumb up 👍
+  THMDN, // thumb down 👎
+  PRAY, // pray 🙏
+  PHEW, // relieved 😌
+  MUSIC, // musical notes
+  FLUSH, // flushed 😳
+  CELEB, // celebration 🙌
+  CRY2, // crying face 😢
+  COOL, // smile with sunglasses 😎
+  NOEVS, // see no evil
+  NOEVH, // hear no evil
+  NOEVK, // speak no evil
+  POO, // pile of poo
+  EYES, // eyes
+  VIC, // victory hand
+  BHART, // broken heart
+  SLEEP, // sleeping face
+  SMIL2, // smiling face with open mouth & sweat
+  HUNRD, // 100
+  CONFU, // confused
+  TONGU, // face with tongue & winking eye
+  DISAP, // disappointed
+  YUMMY, // face savoring delicious food
+  CLAP, // hand clapping
+  FEAR, // face screaming in fear
+  HORNS, // smiling face with horns
+  HALO, // smiling face with halo
+  BYE, // waving hand
+  SUN, // sun
+  MOON, // moon
+  SKULL, // skull
+};
+
+const uint32_t PROGMEM unicode_map[] = {
+  [GRIN] = 0x1F600,
+  [TJOY] = 0x1F602,
+  [SMILE] = 0x1F601,
+  [HEART] = 0x2764,
+  [EYERT] = 0x1f60d,
+  [CRY] = 0x1f62d,
+  [SMEYE] = 0x1F60A,
+  [UNAMU] = 0x1F612,
+  [KISS] = 0x1F618,
+  [HART2] = 0x1F495,
+  [WEARY] = 0x1F629,
+  [OKHND] = 0x1F44C,
+  [PENSV] = 0x1F614,
+  [SMIRK] = 0x1F60F,
+  [RECYC] = 0x267B,
+  [WINK] = 0x1F609,
+  [THMUP] = 0x1F44D,
+  [THMDN] = 0x1F44E,
+  [PRAY] = 0x1F64F,
+  [PHEW] = 0x1F60C,
+  [MUSIC] = 0x1F3B6,
+  [FLUSH] = 0x1F633,
+  [CELEB] = 0x1F64C,
+  [CRY2] = 0x1F622,
+  [COOL] = 0x1F60E,
+  [NOEVS] = 0x1F648,
+  [NOEVH] = 0x1F649,
+  [NOEVK] = 0x1F64A,
+  [POO] = 0x1F4A9,
+  [EYES] = 0x1F440,
+  [VIC] = 0x270C,
+  [BHART] = 0x1F494,
+  [SLEEP] = 0x1F634,
+  [SMIL2] = 0x1F605,
+  [HUNRD] = 0x1F4AF,
+  [CONFU] = 0x1F615,
+  [TONGU] = 0x1F61C,
+  [DISAP] = 0x1F61E,
+  [YUMMY] = 0x1F60B,
+  [CLAP] = 0x1F44F,
+  [FEAR] = 0x1F631,
+  [HORNS] = 0x1F608,
+  [HALO] = 0x1F607,
+  [BYE] = 0x1F44B,
+  [SUN] = 0x2600,
+  [MOON] = 0x1F314,
+  [SKULL] = 0x1F480,
+};
+
+// keymaps
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+/* Qwerty
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |Enter |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Shift |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Ctrl | GUI  | Alt  | Punc | Num  |    Space    | Func |Emoji |AltGr | GUI  | Ctrl |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_QWERTY] = {
+  {KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC},
+  {KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_ENT },
+  {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT},
+  {KC_LCTL, KC_LGUI, KC_LALT, PUNC,    NUM,     KC_SPC,  KC_SPC,  FUNC,    EMOJI,   KC_RALT, KC_RGUI, KC_RCTL}
+},
+
+/* Colemak
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |Enter |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Shift |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Ctrl | GUI  | Alt  | Punc | Num  |    Space    | Func |Emoji |AltGr | GUI  | Ctrl |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_COLEMAK] = {
+  {KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_BSPC},
+  {KC_ESC,  KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_ENT },
+  {KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT},
+  {KC_LCTL, KC_LGUI, KC_LALT, PUNC,    NUM,     KC_SPC,  KC_SPC,  FUNC,    EMOJI,   KC_RALT, KC_RGUI, KC_RCTL}
+},
+
+/* Workman
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |Enter |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Shift |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Ctrl | GUI  | Alt  | Punc | Num  |    Space    | Func |Emoji |AltGr | GUI  | Ctrl |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_WORKMAN] = {
+  {KC_TAB,  KC_Q,    KC_D,    KC_R,    KC_W,    KC_B,    KC_J,    KC_F,    KC_U,    KC_P,    KC_SCLN, KC_BSPC},
+  {KC_ESC,  KC_A,    KC_S,    KC_H,    KC_T,    KC_G,    KC_Y,    KC_N,    KC_E,    KC_O,    KC_I,    KC_ENT },
+  {KC_LSFT, KC_Z,    KC_X,    KC_M,    KC_C,    KC_V,    KC_K,    KC_L,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT},
+  {KC_LCTL, KC_LGUI, KC_LALT, PUNC,    NUM,     KC_SPC,  KC_SPC,  FUNC,    EMOJI,   KC_RALT, KC_RGUI, KC_RCTL}
+},
+
+/* Punc
+ * ,-----------------------------------------------------------------------------------.
+ * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * |   `  |      |      |      |      |      |   |  |   _  |   +  |   {  |   }  |  "   |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |      |      |      |      |      |   \  |   -  |   =  |   [  |   ]  |  '   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      |      |   <  |   >  |      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_PUNC] = {
+  {KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC},
+  {KC_GRV,  _______, _______, _______, _______, _______, KC_PIPE, KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_DQUO},
+  {_______, _______, _______, _______, _______, _______, KC_BSLS, KC_MINS,  KC_EQL, KC_LBRC, KC_RBRC, KC_QUOT},
+  {_______, _______, _______, _______, _______,  KC_SPC,  KC_SPC, _______, _______, KC_LABK, KC_RABK, _______}
+},
+
+/* Num
+ * ,-----------------------------------------------------------------------------------.
+ * |      |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * | Esc  |  @   |  A   |  B   |  C   |  [   |  ]   |   4  |   5  |   6  |   :  |Enter |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |      |  D   |  E   |  F   |  &   |  #   |   1  |   2  |   3  |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |  x   |      |      |             |   0  |   ,  |   .  |      |      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_NUM] = {
+  {_______,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0, KC_BSPC},
+  { KC_ESC,   KC_AT, S(KC_A), S(KC_B), S(KC_C), KC_LBRC, KC_RBRC,    KC_4,    KC_5,    KC_6, KC_COLN, KC_BSLS},
+  {_______, _______, S(KC_D), S(KC_E), S(KC_F), KC_AMPR, KC_HASH,    KC_1,    KC_2,    KC_3, _______, _______},
+  {_______, _______,    KC_X, _______, _______,  KC_SPC,  KC_SPC,    KC_0, KC_COMM,KC_KP_DOT,_______, _______}
+},
+
+/* Func
+ * ,-----------------------------------------------------------------------------------.
+ * |      |  F1  |  F2  |  F3  |  F4  |      |      | PgUp |  Up  | PgDn | PgUp | Bksp |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * |      |  F5  |  F6  |  F7  |  F8  |      |      | Left | Down | Right| PgDn |      |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |  F9  |  F10 |  F11 |  F12 |      |      |      | Home |  End |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      |      |      |      |Print |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_FUNC] = {
+  {_______,   KC_F1,   KC_F2,   KC_F3,   KC_F4, _______, _______, KC_PGUP,   KC_UP, KC_PGDN, KC_PGUP, KC_BSPC},
+  {_______,   KC_F5,   KC_F6,   KC_F7,   KC_F8, _______, _______, KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN, _______},
+  {_______,   KC_F9,  KC_F10,  KC_F11,  KC_F12, _______, _______, _______, KC_HOME,  KC_END, _______, _______},
+  {_______, _______, _______, _______, _______, _______, _______, _______, _______, _______,_______,KC_PSCREEN}
+},
+
+/* Emoji
+ * ,-----------------------------------------------------------------------------------.
+ * |      |      |      |      |      |      |      |      |      |      |      |      |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      |      |      |      |      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_EMOJI] = {
+  {X(HART2), X(CRY2),X(WEARY),X(EYERT),X(SMIRK), X(TJOY),X(RECYC),X(UNAMU),X(MUSIC),X(OKHND),X(PENSV), X(PHEW)},
+  {X(THMUP), X(PRAY),X(SMILE),X(SMIL2),X(FLUSH), X(GRIN),X(HEART),  X(BYE), X(KISS),X(CELEB), X(COOL),X(NOEVS)},
+  {X(THMDN),X(SLEEP), X(CLAP),  X(CRY),  X(VIC),X(BHART),  X(SUN),X(SMEYE), X(WINK), X(MOON),X(CONFU),X(NOEVH)},
+  {  X(POO), X(EYES),X(HUNRD),X(TONGU),X(SKULL),X(HORNS), X(HALO), X(FEAR), _______,X(YUMMY),X(DISAP),X(NOEVK)}
+},
+
+/* Adjust
+ * ,-----------------------------------------------------------------------------------.
+ * |      |      |Linux | Win  | OSX  |      |      |Qwerty|Colemk|Workmm|      |      |
+ * |------+------+------+------+------+-------------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      |      |      |      |      |
+ * |------+------+------+------+------+------|------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      |      |      |      |      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_ADJUST] = {
+  {_______, _______,   LINUX,     WIN,     OSX, _______, _______, QWERTY,  COLEMAK, WORKMAN, _______, _______},
+  {_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______},
+  {_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______},
+  {_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______}
+}
+
+
+};
+
+#ifdef AUDIO_ENABLE
+float tone_startup[][2]    = SONG(STARTUP_SOUND);
+float tone_qwerty[][2]     = SONG(QWERTY_SOUND);
+float tone_colemak[][2]    = SONG(COLEMAK_SOUND);
+float tone_workman[][2]    = SONG(DVORAK_SOUND);
+float tone_goodbye[][2] = SONG(GOODBYE_SOUND);
+#endif
+
+void persistant_default_layer_set(uint16_t default_layer) {
+  eeconfig_update_default_layer(default_layer);
+  default_layer_set(default_layer);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        #ifdef AUDIO_ENABLE
+          PLAY_NOTE_ARRAY(tone_qwerty, false, 0);
+        #endif
+        persistant_default_layer_set(1UL<<_QWERTY);
+      }
+      return false;
+      break;
+    case COLEMAK:
+      if (record->event.pressed) {
+        #ifdef AUDIO_ENABLE
+          PLAY_NOTE_ARRAY(tone_colemak, false, 0);
+        #endif
+        persistant_default_layer_set(1UL<<_COLEMAK);
+      }
+      return false;
+      break;
+    case WORKMAN:
+      if (record->event.pressed) {
+        #ifdef AUDIO_ENABLE
+          PLAY_NOTE_ARRAY(tone_workman, false, 0);
+        #endif
+        persistant_default_layer_set(1UL<<_WORKMAN);
+      }
+      return false;
+      break;
+    case PUNC:
+      if (record->event.pressed) {
+        layer_on(_PUNC);
+        update_tri_layer(_PUNC, _EMOJI, _ADJUST);
+      } else {
+        layer_off(_PUNC);
+        update_tri_layer(_PUNC, _EMOJI, _ADJUST);
+      }
+      return false;
+      break;
+    case EMOJI:
+      if (record->event.pressed) {
+        layer_on(_EMOJI);
+        update_tri_layer(_PUNC, _EMOJI, _ADJUST);
+      } else {
+        layer_off(_EMOJI);
+        update_tri_layer(_PUNC, _EMOJI, _ADJUST);
+      }
+      return false;
+      break;
+    case NUM:
+      if (record->event.pressed) {
+        layer_on(_NUM);
+      } else {
+        layer_off(_NUM);
+      }
+      return false;
+      break;
+    case FUNC:
+      if (record->event.pressed) {
+        layer_on(_FUNC);
+      } else {
+        layer_off(_FUNC);
+      }
+      return false;
+      break;
+    case LINUX:
+      set_unicode_input_mode(UC_LNX);
+      return false;
+      break;
+    case WIN:
+      set_unicode_input_mode(UC_WIN);
+      return false;
+      break;
+    case OSX:
+      set_unicode_input_mode(UC_OSX);
+      return false;
+      break;
+  }
+  return true;
+}
+
+void matrix_init_user(void) {
+  #ifdef AUDIO_ENABLE
+      startup_user();
+  #endif
+  set_unicode_input_mode(UC_LNX);
+}
+
+#ifdef AUDIO_ENABLE
+
+void startup_user()
+{
+    _delay_ms(20); // gets rid of tick
+    PLAY_NOTE_ARRAY(tone_startup, false, 0);
+}
+
+void shutdown_user()
+{
+    PLAY_NOTE_ARRAY(tone_goodbye, false, 0);
+    _delay_ms(150);
+    stop_all_notes();
+}
+
+#endif

--- a/keyboards/planck/keymaps/priyadi/readme.md
+++ b/keyboards/planck/keymaps/priyadi/readme.md
@@ -1,0 +1,1 @@
+# Priyadi's Planck Layout

--- a/quantum/keymap.h
+++ b/quantum/keymap.h
@@ -84,6 +84,10 @@ enum quantum_keycodes {
     QK_MOD_TAP_MAX        = 0x6FFF,
     QK_TAP_DANCE          = 0x7100,
     QK_TAP_DANCE_MAX      = 0x71FF,
+#ifdef UNICODEMAP_ENABLE
+    QK_UNICODE_MAP        = 0x7800,
+    QK_UNICODE_MAP_MAX    = 0x7FFF,
+#endif
 #ifdef UNICODE_ENABLE
     QK_UNICODE            = 0x8000,
     QK_UNICODE_MAX        = 0xFFFF,
@@ -335,5 +339,8 @@ enum quantum_keycodes {
     #define UC(n) UNICODE(n)
 #endif
 
+#ifdef UNICODEMAP_ENABLE
+    #define X(n) (n | QK_UNICODE_MAP)
+#endif
 
 #endif

--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -78,6 +78,32 @@ bool process_unicode(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
+#ifdef UNICODEMAP_ENABLE
+__attribute__((weak))
+const uint32_t PROGMEM unicode_map[] = {
+};
+
+// 5 digit max because of linux limitation
+void register_hex32(uint32_t hex) {
+  for(int i = 4; i >= 0; i--) {
+    uint8_t digit = ((hex >> (i*4)) & 0xF);
+    register_code(hex_to_keycode(digit));
+    unregister_code(hex_to_keycode(digit));
+  }
+}
+
+bool process_unicode_map(uint16_t keycode, keyrecord_t *record) {
+  if ((keycode & QK_UNICODE_MAP) == QK_UNICODE_MAP && record->event.pressed) {
+    const uint32_t* map = unicode_map;
+    uint16_t index = keycode & 0x7FF;
+    unicode_input_start();
+    register_hex32(pgm_read_dword_far(&map[index]));
+    unicode_input_finish();
+  }
+  return true;
+}
+#endif
+
 #ifdef UCIS_ENABLE
 qk_ucis_state_t qk_ucis_state;
 

--- a/quantum/process_keycode/process_unicode.h
+++ b/quantum/process_keycode/process_unicode.h
@@ -20,6 +20,10 @@ void register_hex(uint16_t hex);
 
 bool process_unicode(uint16_t keycode, keyrecord_t *record);
 
+#ifdef UNICODEMAP_ENABLE
+bool process_unicode_map(uint16_t keycode, keyrecord_t *record);
+#endif
+
 #ifdef UCIS_ENABLE
 #ifndef UCIS_MAX_SYMBOL_LENGTH
 #define UCIS_MAX_SYMBOL_LENGTH 32

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -129,6 +129,9 @@ bool process_record_quantum(keyrecord_t *record) {
   #ifdef UCIS_ENABLE
     process_ucis(keycode, record) &&
   #endif
+  #ifdef UNICODEMAP_ENABLE
+    process_unicode_map(keycode, record) &&
+  #endif
       true)) {
     return false;
   }

--- a/readme.md
+++ b/readme.md
@@ -320,6 +320,12 @@ This enables MIDI sending and receiving with your keyboard. To enter MIDI send m
 
 This allows you to send unicode symbols via `UC(<unicode>)` in your keymap. Only codes up to 0x7FFF are currently supported.
 
+`UNICODEMAP_ENABLE`
+
+This allows sending unicode symbols using `X(<unicode>)` in your keymap. Codes
+up to 0xFFFFF are supported, including emojis. But you need to maintain a
+separate mapping table in your keymap file.
+
 `BLUETOOTH_ENABLE`
 
 This allows you to interface with a Bluefruit EZ-key to send keycodes wirelessly. It uses the D2 and D3 pins.


### PR DESCRIPTION
This allows unicode input up to 0xFFFFF using a mapping table in keymap file.

Some notes:

- To use, add ```UNICODEMAP_ENABLE = yes``` in Makefile
- Takes the range 0x7800-0x78FF in keycodes, hence a maximum of 2048 unicode characters are supported in a single keymap file.
- Need a mapping array in keymap file in the form of ```const uint32_t PROGMEM unicode_map[] = ...```
- Uses the macro ```X()``` in keymap file, to refer to a value in mapping table.
- Could easily support up to 0xFFFFFFFF, but Linux only supports inputting 5 characters max, so I'm limiting to 5 bytes for now.