### PR TITLE
Added VS Code dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ CMakeLists.txt
 .browse.VC.db*
 *.stackdump
 util/Win_Check_Output.txt
+.vscode


### PR DESCRIPTION
I had an incident using Visual Studio Code as an editor where it tried to add several metadata files in the .vscode directory to a commit. This pull request just adds that directory to .gitignore.

Thanks!