### PR TITLE
UNICODE_MAP: remove 5 char limit; ignore leading zeroes; handle OS limitations

### DIFF
--- a/quantum/process_keycode/process_unicode.c
+++ b/quantum/process_keycode/process_unicode.c
@@ -83,22 +83,42 @@ __attribute__((weak))
 const uint32_t PROGMEM unicode_map[] = {
 };
 
-// 5 digit max because of linux limitation
 void register_hex32(uint32_t hex) {
-  for(int i = 4; i >= 0; i--) {
+  uint8_t onzerostart = 1;
+  for(int i = 7; i >= 0; i--) {
+    if (i <= 3) {
+      onzerostart = 0;
+    }
     uint8_t digit = ((hex >> (i*4)) & 0xF);
-    register_code(hex_to_keycode(digit));
-    unregister_code(hex_to_keycode(digit));
+    if (digit == 0) {
+      if (onzerostart == 0) {
+        register_code(hex_to_keycode(digit));
+        unregister_code(hex_to_keycode(digit));
+      }
+    } else {
+      register_code(hex_to_keycode(digit));
+      unregister_code(hex_to_keycode(digit));
+      onzerostart = 0;
+    }
   }
 }
+
+__attribute__((weak))
+void unicode_map_input_error() {}
 
 bool process_unicode_map(uint16_t keycode, keyrecord_t *record) {
   if ((keycode & QK_UNICODE_MAP) == QK_UNICODE_MAP && record->event.pressed) {
     const uint32_t* map = unicode_map;
     uint16_t index = keycode & 0x7FF;
-    unicode_input_start();
-    register_hex32(pgm_read_dword_far(&map[index]));
-    unicode_input_finish();
+    uint32_t code = pgm_read_dword_far(&map[index]);
+    if ((code > 0xFFFF && input_mode == UC_OSX) || (code > 0xFFFFF && input_mode == UC_LNX)) {
+      // when character is out of range supported by the OS
+      unicode_map_input_error();
+    } else {
+      unicode_input_start();
+      register_hex32(code);
+      unicode_input_finish();
+    }
   }
   return true;
 }

--- a/readme.md
+++ b/readme.md
@@ -326,8 +326,14 @@ This allows you to send unicode symbols via `UC(<unicode>)` in your keymap. Only
 `UNICODEMAP_ENABLE`
 
 This allows sending unicode symbols using `X(<unicode>)` in your keymap. Codes
-up to 0xFFFFF are supported, including emojis. But you need to maintain a
-separate mapping table in your keymap file.
+up to 0xFFFFFFFF are supported, including emojis. You will need to maintain
+a separate mapping table in your keymap file.
+
+Known limitations:
+- Under Mac OS, only codes up to 0xFFFF are supported.
+- Under Linux ibus, only codes up to 0xFFFFF are supported (but anything important is still under this limit for now).
+
+Characters out of range supported by the OS will be ignored.
 
 `BLUETOOTH_ENABLE`
 


### PR DESCRIPTION
Unicode map improvements:

- skip inputting leading zeroes, except on fourth character onward (because Mac OS expects 4 characters input)
- check if character is out of range supported by the OS, and skips it. 
- weak ```unicode_map_input_error()``` to handle out of range input, to be implemented by individual keymaps, e.g. for error beeps
- documentation updates