### PR TITLE
Add subproject env var to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
 ENV keyboard=ergodox
+ENV subproject=ez
 ENV keymap=default
 
 VOLUME /qmk
 WORKDIR /qmk
-CMD make clean ; make keyboard=${keyboard} keymap=${keymap}
+CMD make clean ; make keyboard=${keyboard} subproject=${subproject} keymap=${keymap}


### PR DESCRIPTION
Fix the `Dockerfile` build image by adding the mandatory subproject variable.
