### PR TITLE
Switched to momentary

### DIFF
--- a/keyboards/ergodox/keymaps/j3rn/keymap.c
+++ b/keyboards/ergodox/keymaps/j3rn/keymap.c
@@ -36,21 +36,21 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_TAB,         KC_Q,         KC_W,   KC_E,   KC_R,   KC_T,   KC_MINS,
         CTL_T(KC_ESC),  KC_A,         KC_S,   KC_D,   KC_F,   KC_G,
         KC_LSFT,        CTL_T(KC_Z),  KC_X,   KC_C,   KC_V,   KC_B,   ALL_T(KC_NO),
-        KC_FN1,         KC_LALT,      LALT(KC_LSFT),  KC_LEFT,KC_RGHT,
+        MO(SYMB),       KC_LALT,      LALT(KC_LSFT),  KC_LEFT,KC_RGHT,
 
                                               ALT_T(KC_APP),  KC_HOME,
                                                               KC_END,
-                                       KC_SPC,   KC_LGUI,     KC_FN2,
+                                               KC_SPC,KC_LGUI,MO(MDIA),
         // right hand
              KC_RBRC,     KC_6,   KC_7,   KC_8,   KC_9,   KC_0,             KC_BSPC,
              KC_EQL,      KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,             KC_BSLS,
                           KC_H,   KC_J,   KC_K,   KC_L,   KC_SCLN,          KC_QUOT,
              MEH_T(KC_NO),KC_N,   KC_M,   KC_COMM,KC_DOT, CTL_T(KC_SLSH),   KC_RSFT,
-                                  KC_UP,  KC_DOWN,KC_LBRC,KC_RBRC,          KC_FN1,
+                                  KC_UP,  KC_DOWN,KC_LBRC,KC_RBRC,          MO(SYMB),
 
-             KC_PGUP, CTL_T(KC_ESC),
+             KC_PGUP,         CTL_T(KC_ESC),
              KC_PGDN,
-             KC_FN1,    KC_TAB,     KC_ENT
+             MO(SYMB),KC_TAB, KC_ENT
     ),
 /* Keymap 1: Symbol Layer
  *


### PR DESCRIPTION
I prefer my level-switching keys to be momentary instead of the previous toggle/momentary way they used to be.
