### PR TITLE
Increase the infinity60 system tick frequency

### DIFF
--- a/keyboards/infinity60/chconf.h
+++ b/keyboards/infinity60/chconf.h
@@ -48,7 +48,7 @@
  * @details Frequency of the system timer that drives the system ticks. This
  *          setting also defines the system tick time unit.
  */
-#define CH_CFG_ST_FREQUENCY                 1000
+#define CH_CFG_ST_FREQUENCY                 100000
 
 /**
  * @brief   Time delta constant for the tick-less mode.

--- a/keyboards/infinity60/matrix.c
+++ b/keyboards/infinity60/matrix.c
@@ -96,7 +96,12 @@ uint8_t matrix_scan(void)
         }
     #endif
 
-        wait_us(1); // need wait to settle pin state
+        // need wait to settle pin state
+        // if you wait too short, or have a too high update rate
+        // the keyboard might freeze, or there might not be enough
+        // processing power to update the LCD screen properly.
+        // 20us, or two ticks at 100000Hz seems to be OK
+        wait_us(20);
 
         // read col data
         data = (palReadPort(GPIOD)>>1);


### PR DESCRIPTION
The system tick frequency was set to 1000, so the minimum waitable time is 1ms. This causes a slow matrix scan as reported in #855. This sets it to 100000 or 10us.

I don't own an Infinity 60, so I haven't been able to test this myself, therefore I need someone to test it before it can be merged. The code is the same as I use for the Infinity Ergodox so at least it works there. However the Infinity 60 has a weaker processor so the magic 20us wait in the matrix scan might not be correct for that keyboard.