### PR TITLE
Variable trace

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -180,6 +180,8 @@ ifeq ($(strip $(SERIAL_LINK_ENABLE)), yes)
 	VAPTH += $(SERIAL_PATH)
 endif
 
+SRC += $(QUANTUM_DIR)/variable_trace.c
+
 # Optimize size but this may cause error "relocation truncated to fit"
 #EXTRALDFLAGS = -Wl,--relax
 

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -180,7 +180,13 @@ ifeq ($(strip $(SERIAL_LINK_ENABLE)), yes)
 	VAPTH += $(SERIAL_PATH)
 endif
 
-SRC += $(QUANTUM_DIR)/variable_trace.c
+ifneq ($(strip $(VARIABLE_TRACE)),)
+	SRC += $(QUANTUM_DIR)/variable_trace.c
+	OPT_DEFS += -DNUM_TRACED_VARIABLES=$(strip $(VARIABLE_TRACE))
+ifneq ($(strip $(MAX_VARIABLE_TRACE_SIZE)),)
+	OPT_DEFS += -DMAX_VARIABLE_TRACE_SIZE=$(strip $(MAX_VARIABLE_TRACE_SIZE))
+endif
+endif
 
 # Optimize size but this may cause error "relocation truncated to fit"
 #EXTRALDFLAGS = -Wl,--relax

--- a/quantum/variable_trace.c
+++ b/quantum/variable_trace.c
@@ -1,0 +1,108 @@
+#include "variable_trace.h"
+#include <stddef.h>
+#include <string.h>
+
+#ifdef NO_PRINT
+#error "You need undef NO_PRINT to use the variable trace feature"
+#endif
+
+#ifndef CONSOLE_ENABLE
+#error "The console needs to be enabled in the makefile to use the variable trace feature"
+#endif
+
+
+#define NUM_TRACED_VARIABLES 1
+#define MAX_TRACE_SIZE 4
+
+typedef struct {
+    const char* name;
+    void* addr;
+    unsigned size;
+    const char* func;
+    int line;
+    uint8_t last_value[MAX_TRACE_SIZE];
+
+} traced_variable_t;
+
+static traced_variable_t traced_variables[NUM_TRACED_VARIABLES];
+
+void add_traced_variable(const char* name, void* addr, unsigned size, const char* func, int line) {
+    verify_traced_variables(func, line);
+    if (size > MAX_TRACE_SIZE) {
+#if defined(__AVR__)
+       xprintf("Traced variable \"%S\" exceeds the maximum size %d\n", name, size);
+#else
+       xprintf("Traced variable \"%s\" exceeds the maximum size %d\n", name, size);
+#endif
+       size = MAX_TRACE_SIZE;
+    }
+    int index = -1;
+    for (int i = 0; i < NUM_TRACED_VARIABLES; i++) {
+        if (index == -1 && traced_variables[i].addr == NULL){
+            index = i;
+        }
+        else if (strcmp_P(name, traced_variables[i].name)==0) {
+            index = i;
+            break;
+        }
+    }
+
+    if (index == -1) {
+        xprintf("You can only trace %d variables at the same time\n", NUM_TRACED_VARIABLES);
+        return;
+    }
+
+    traced_variable_t* t = &traced_variables[index];
+    t->name = name;
+    t->addr = addr;
+    t->size = size;
+    t->func = func;
+    t->line = line;
+    memcpy(&t->last_value[0], addr, size);
+
+}
+
+void remove_traced_variable(const char* name, const char* func, int line) {
+    verify_traced_variables(func, line);
+    for (int i = 0; i < NUM_TRACED_VARIABLES; i++) {
+        if (strcmp_P(name, traced_variables[i].name)==0) {
+            traced_variables[i].name = 0;
+            traced_variables[i].addr = NULL;
+            break;
+        }
+    }
+}
+
+void verify_traced_variables(const char* func, int line) {
+    for (int i = 0; i < NUM_TRACED_VARIABLES; i++) {
+        traced_variable_t* t = &traced_variables[i];
+        if (t->addr != NULL && t->name != NULL) {
+            if (memcmp(t->last_value, t->addr, t->size)!=0){
+#if defined(__AVR__)
+               xprintf("Traced variable \"%S\" has been modified\n", t->name);
+               xprintf("Between %S:%d\n", t->func, t->line);
+               xprintf("And %S:%d\n", func, line);
+
+#else
+               xprintf("Traced variable \"%s\" has been modified\n", t->name);
+               xprintf("Between %s:%d\n", t->func, t->line);
+               xprintf("And %s:%d\n", func, line);
+#endif
+               xprintf("Previous value ");
+               for (int j=0; j<t->size;j++) {
+                   print_hex8(t->last_value[j]);
+               }
+               xprintf("\nNew value ");
+               uint8_t* addr = (uint8_t*)(t->addr);
+               for (int j=0; j<t->size;j++) {
+                   print_hex8(addr[j]);
+               }
+               xprintf("\n");
+               memcpy(t->last_value, addr, t->size);
+           }
+        }
+
+        t->func = func;
+        t->line = line;
+    }
+}

--- a/quantum/variable_trace.c
+++ b/quantum/variable_trace.c
@@ -12,7 +12,9 @@
 
 
 #define NUM_TRACED_VARIABLES 1
-#define MAX_TRACE_SIZE 4
+#ifndef MAX_VARIABLE_TRACE_SIZE
+    #define MAX_VARIABLE_TRACE_SIZE 4
+#endif
 
 typedef struct {
     const char* name;
@@ -20,7 +22,7 @@ typedef struct {
     unsigned size;
     const char* func;
     int line;
-    uint8_t last_value[MAX_TRACE_SIZE];
+    uint8_t last_value[MAX_VARIABLE_TRACE_SIZE];
 
 } traced_variable_t;
 
@@ -28,13 +30,13 @@ static traced_variable_t traced_variables[NUM_TRACED_VARIABLES];
 
 void add_traced_variable(const char* name, void* addr, unsigned size, const char* func, int line) {
     verify_traced_variables(func, line);
-    if (size > MAX_TRACE_SIZE) {
+    if (size > MAX_VARIABLE_TRACE_SIZE) {
 #if defined(__AVR__)
        xprintf("Traced variable \"%S\" exceeds the maximum size %d\n", name, size);
 #else
        xprintf("Traced variable \"%s\" exceeds the maximum size %d\n", name, size);
 #endif
-       size = MAX_TRACE_SIZE;
+       size = MAX_VARIABLE_TRACE_SIZE;
     }
     int index = -1;
     for (int i = 0; i < NUM_TRACED_VARIABLES; i++) {

--- a/quantum/variable_trace.h
+++ b/quantum/variable_trace.h
@@ -1,0 +1,25 @@
+#ifndef VARIABLE_TRACE_H
+#define VARIABLE_TRACE_H
+
+#include "print.h"
+
+#ifdef NUM_TRACED_VARIABLES
+
+#define ADD_TRACED_VARIABLE(name, addr, size) \
+    add_traced_variable(PSTR(name), (void*)addr, size, PSTR(__FILE__), __LINE__)
+#define REMOVE_TRACED_VARIABLE(name) remove_traced_variable(PSTR(name), PSTR(__FILE__), __LINE__)
+#define VERIFY_TRACED_VARIABLES() verify_traced_variables(PSTR(__FILE__), __LINE__)
+
+#else
+
+#define ADD_TRACED_VARIABLE(name, addr, size)
+#define REMOVE_TRACED_VARIABLE(name)
+#define VERIFY_TRACED_VARIABLES()
+
+#endif
+
+// Don't call directly, use the macros instead
+void add_traced_variable(const char* name, void* addr, unsigned size, const char* func, int line);
+void remove_traced_variable(const char* name, const char* func, int line);
+void verify_traced_variables(const char* func, int line);
+#endif

--- a/quantum/variable_trace.h
+++ b/quantum/variable_trace.h
@@ -1,13 +1,22 @@
 #ifndef VARIABLE_TRACE_H
 #define VARIABLE_TRACE_H
 
+// For more information about the variable tracing see the readme.
+
 #include "print.h"
 
 #ifdef NUM_TRACED_VARIABLES
 
+// Start tracing a variable at the memory address addr
+// The name can be anything and is used only for reporting
+// The size should usually be the same size as the variable you are interested in
 #define ADD_TRACED_VARIABLE(name, addr, size) \
     add_traced_variable(PSTR(name), (void*)addr, size, PSTR(__FILE__), __LINE__)
+
+// Stop tracing the variable with the given name
 #define REMOVE_TRACED_VARIABLE(name) remove_traced_variable(PSTR(name), PSTR(__FILE__), __LINE__)
+
+// Call to get messages when the variable has been changed
 #define VERIFY_TRACED_VARIABLES() verify_traced_variables(PSTR(__FILE__), __LINE__)
 
 #else


### PR DESCRIPTION
# Tracing variables 

Sometimes you might wonder why a variable gets changed and where, and this can be quite tricky to track down without having a debugger. It's of course possible to manually add print statements to track it, but you can also enable the variable trace feature. This works for both for variables that are changed by the code, and when the variable is changed by some memory corruption.

To take the feature into use add `VARIABLE_TRACE=x` to the end of you make command. `x` represents the number of variables you want to trace, which is usually 1. 

Then at a suitable place in the code, call `ADD_TRACED_VARIABLE`, to begin the tracing. For example to trace all the layer changes, you can do this
```c
void matrix_init_user(void) {
  ADD_TRACED_VARIABLE("layer", &layer_state, sizeof(layer_state));
}
```

This will add a traced variable named "layer" (the name is just for your information), which tracks the memory location of `layer_state`. It tracks 4 bytes (the size of `layer_state`), so any modification to the variable will be reported. By default you can not specify a size bigger than 4, but you can change it by adding `MAX_VARIABLE_TRACE_SIZE=x` to the end of the make command line.

In order to actually detect changes to the variables you should call `VERIFY_TRACED_VARIABLES` around the code that you think that modifies the variable. If a variable is modified it will tell you between which two `VERIFY_TRACED_VARIABLES` calls the modification happened. You can then add more calls to track it down further. I don't recommend spamming the codebase with calls. It's better to start with a few, and then keep adding them in a binary search fashion. You can also delete the ones you don't need, as each call need to store the file name and line number in the ROM, so you can run out of memory if you add too many calls.

Also remember to delete all the tracing code ones you have found the bug, as you wouldn't want to create a pull request with tracing code.
