### PR TITLE
atreus62 Keyboard Support

### DIFF
--- a/keyboards/atreus62/Makefile
+++ b/keyboards/atreus62/Makefile
@@ -1,0 +1,3 @@
+ifndef MAKEFILE_INCLUDED
+	include ../../Makefile
+endif

--- a/keyboards/atreus62/atreus62.c
+++ b/keyboards/atreus62/atreus62.c
@@ -1,0 +1,1 @@
+#include "atreus62.h"

--- a/keyboards/atreus62/atreus62.h
+++ b/keyboards/atreus62/atreus62.h
@@ -1,0 +1,26 @@
+#ifndef ATREUS62_H
+#define ATREUS62_H
+
+#include "quantum.h"
+
+void promicro_bootloader_jmp(bool program);
+
+// This a shortcut to help you visually see your layout.
+// The first section contains all of the arguements
+// The second converts the arguments into a two-dimensional array
+#define KEYMAP( \
+  k00, k01, k02, k03, k04, k05,           k06, k07, k08, k09, k0a, k0b, \
+  k10, k11, k12, k13, k14, k15,           k16, k17, k18, k19, k1a, k1b, \
+  k20, k21, k22, k23, k24, k25,           k26, k27, k28, k29, k2a, k2b, \
+  k30, k31, k32, k33, k34, k35,           k36, k37, k38, k39, k3a, k3b, \
+  k40, k41, k42, k43, k44, k45, k46, k47, k48, k49, k4a, k4b, k4c, k4d \
+) \
+{ \
+	{ k00, k01, k02, k03, k04, k05, KC_NO, k06, k07, k08, k09, k0a, k0b }, \
+	{ k10, k11, k12, k13, k14, k15, KC_NO, k16, k17, k18, k19, k1a, k1b }, \
+	{ k20, k21, k22, k23, k24, k25, KC_NO, k26, k27, k28, k29, k2a, k2b }, \
+	{ k30, k31, k32, k33, k34, k35, k46,   k36, k37, k38, k39, k3a, k3b }, \
+	{ k40, k41, k42, k43, k44, k45, k47,   k48, k49, k4a, k4b, k4c, k4d } \
+}
+
+#endif

--- a/keyboards/atreus62/config.h
+++ b/keyboards/atreus62/config.h
@@ -1,0 +1,83 @@
+/*
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "config_common.h"
+
+/* USB Device descriptor parameter */
+
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x6062
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    Profet
+#define PRODUCT         Atreus62
+#define DESCRIPTION     q.m.k. keyboard firmware for Atreus62
+
+/* key matrix size */
+// Rows are doubled-up
+#define MATRIX_ROWS 5
+#define MATRIX_COLS 13
+
+// wiring of each half
+#define MATRIX_ROW_PINS { D2, D3, D1, D0, D4 }
+#define MATRIX_COL_PINS { F4, F5, F6, F7, B1, B3, B2, B6, B5, B4, E6, D7, C6 }
+
+#define CATERINA_BOOTLOADER
+
+/* COL2ROW or ROW2COL */
+#define DIODE_DIRECTION ROW2COL
+
+/* define if matrix has ghost */
+//#define MATRIX_HAS_GHOST
+
+/* number of backlight levels */
+// #define BACKLIGHT_LEVELS 3
+
+/* Set 0 if debouncing isn't needed */
+#define DEBOUNCING_DELAY 5
+
+/* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
+#define LOCKING_SUPPORT_ENABLE
+/* Locking resynchronize hack */
+#define LOCKING_RESYNC_ENABLE
+
+/* key combination for command */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+)
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+// #define NO_DEBUG
+
+/* disable print */
+// #define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION
+
+#endif

--- a/keyboards/atreus62/keymaps/default/keymap.c
+++ b/keyboards/atreus62/keymaps/default/keymap.c
@@ -1,0 +1,71 @@
+// this is the style you want to emulate.
+// This is the canonical layout file for the Quantum project. If you want to add another keyboard,
+
+#include "atreus62.h"
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+#define _DEFAULT 0
+#define _NAV 1
+#define _RESET 2
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[_DEFAULT] = { /* qwerty */
+		{ KC_ESC,   KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_TRNS,  KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS },
+		{ KC_BSLS,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_TRNS,  KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_RBRC },
+		{ KC_TAB,   KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_TRNS,  KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT },
+		{ KC_LSFT,  KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_DELT,  KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_LBRC },
+		{ KC_LCTL,  KC_LGUI, KC_LALT, KC_GRV,  MO(_NAV),KC_BSPC, KC_ENT,   KC_SPC,  KC_EQL,  KC_MINS, KC_QUOT, KC_ENT,  KC_RGUI }
+},
+
+[_NAV] = { 
+		{ TO(_DEFAULT),  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_TRNS,  KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11  },
+		{ KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_F12,  KC_TRNS, KC_UP,   KC_TRNS, KC_TRNS, KC_TRNS },
+		{ KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_LEFT, KC_DOWN, KC_RGHT, KC_TRNS, KC_TRNS },
+		{ TO(_RESET),    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS },
+		{ KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS }
+},
+
+[_RESET] = {
+		{ TO(_DEFAULT),  KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  ,  KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO   },
+		{ KC_NO  ,       KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  ,  KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO   },
+		{ KC_NO  ,       KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  ,  KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO   },
+		{ KC_NO  ,       KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  ,  KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO   },
+		{ KC_NO  ,       KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  ,  KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , RESET }
+}
+
+
+/*
+[_TRNS] = {
+		{ KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS },
+		{ KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS },
+		{ KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS },
+		{ KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS },
+		{ KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS }
+},
+*/
+};
+
+
+
+const uint16_t PROGMEM fn_actions[] = {
+
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
+{
+	// MACRODOWN only works in this function
+	switch (id) {
+	case 0:
+		if (record->event.pressed) {
+			register_code(KC_RSFT);
+		}
+		else {
+			unregister_code(KC_RSFT);
+		}
+		break;
+	}
+	return MACRO_NONE;
+};

--- a/keyboards/atreus62/pro_micro.h
+++ b/keyboards/atreus62/pro_micro.h
@@ -1,0 +1,362 @@
+/*
+  pins_arduino.h - Pin definition functions for Arduino
+  Part of Arduino - http://www.arduino.cc/
+
+  Copyright (c) 2007 David A. Mellis
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General
+  Public License along with this library; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+  Boston, MA  02111-1307  USA
+
+  $Id: wiring.h 249 2007-02-03 16:52:51Z mellis $
+*/
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <avr/pgmspace.h>
+
+// Workaround for wrong definitions in "iom32u4.h".
+// This should be fixed in the AVR toolchain.
+#undef UHCON
+#undef UHINT
+#undef UHIEN
+#undef UHADDR
+#undef UHFNUM
+#undef UHFNUML
+#undef UHFNUMH
+#undef UHFLEN
+#undef UPINRQX
+#undef UPINTX
+#undef UPNUM
+#undef UPRST
+#undef UPCONX
+#undef UPCFG0X
+#undef UPCFG1X
+#undef UPSTAX
+#undef UPCFG2X
+#undef UPIENX
+#undef UPDATX
+#undef TCCR2A
+#undef WGM20
+#undef WGM21
+#undef COM2B0
+#undef COM2B1
+#undef COM2A0
+#undef COM2A1
+#undef TCCR2B
+#undef CS20
+#undef CS21
+#undef CS22
+#undef WGM22
+#undef FOC2B
+#undef FOC2A
+#undef TCNT2
+#undef TCNT2_0
+#undef TCNT2_1
+#undef TCNT2_2
+#undef TCNT2_3
+#undef TCNT2_4
+#undef TCNT2_5
+#undef TCNT2_6
+#undef TCNT2_7
+#undef OCR2A
+#undef OCR2_0
+#undef OCR2_1
+#undef OCR2_2
+#undef OCR2_3
+#undef OCR2_4
+#undef OCR2_5
+#undef OCR2_6
+#undef OCR2_7
+#undef OCR2B
+#undef OCR2_0
+#undef OCR2_1
+#undef OCR2_2
+#undef OCR2_3
+#undef OCR2_4
+#undef OCR2_5
+#undef OCR2_6
+#undef OCR2_7
+
+#define NUM_DIGITAL_PINS  30
+#define NUM_ANALOG_INPUTS 12
+
+#define TX_RX_LED_INIT  DDRD |= (1<<5), DDRB |= (1<<0)
+#define TXLED0          PORTD |= (1<<5)
+#define TXLED1          PORTD &= ~(1<<5)
+#define RXLED0          PORTB |= (1<<0)
+#define RXLED1          PORTB &= ~(1<<0)
+
+static const uint8_t SDA = 2;
+static const uint8_t SCL = 3;
+#define LED_BUILTIN 13
+
+// Map SPI port to 'new' pins D14..D17
+static const uint8_t SS   = 17;
+static const uint8_t MOSI = 16;
+static const uint8_t MISO = 14;
+static const uint8_t SCK  = 15;
+
+// Mapping of analog pins as digital I/O
+// A6-A11 share with digital pins
+static const uint8_t ADC0 = 18;
+static const uint8_t ADC1 = 19;
+static const uint8_t ADC2 = 20;
+static const uint8_t ADC3 = 21;
+static const uint8_t ADC4 = 22;
+static const uint8_t ADC5 = 23;
+static const uint8_t ADC6 = 24;   // D4
+static const uint8_t ADC7 = 25;   // D6
+static const uint8_t ADC8 = 26;   // D8
+static const uint8_t ADC9 = 27;   // D9
+static const uint8_t ADC10 = 28;  // D10
+static const uint8_t ADC11 = 29;  // D12
+
+#define digitalPinToPCICR(p)    ((((p) >= 8 && (p) <= 11) || ((p) >= 14 && (p) <= 17) || ((p) >= A8 && (p) <= A10)) ? (&PCICR) : ((uint8_t *)0))
+#define digitalPinToPCICRbit(p) 0
+#define digitalPinToPCMSK(p)    ((((p) >= 8 && (p) <= 11) || ((p) >= 14 && (p) <= 17) || ((p) >= A8 && (p) <= A10)) ? (&PCMSK0) : ((uint8_t *)0))
+#define digitalPinToPCMSKbit(p) ( ((p) >= 8 && (p) <= 11) ? (p) - 4 : ((p) == 14 ? 3 : ((p) == 15 ? 1 : ((p) == 16 ? 2 : ((p) == 17 ? 0 : (p - A8 + 4))))))
+
+//  __AVR_ATmega32U4__ has an unusual mapping of pins to channels
+extern const uint8_t PROGMEM analog_pin_to_channel_PGM[];
+#define analogPinToChannel(P)  ( pgm_read_byte( analog_pin_to_channel_PGM + (P) ) )
+
+#define digitalPinToInterrupt(p) ((p) == 0 ? 2 : ((p) == 1 ? 3 : ((p) == 2 ? 1 : ((p) == 3 ? 0 : ((p) == 7 ? 4 : NOT_AN_INTERRUPT)))))
+
+#ifdef ARDUINO_MAIN
+
+// On the Arduino board, digital pins are also used
+// for the analog output (software PWM).  Analog input
+// pins are a separate set.
+
+// ATMEL ATMEGA32U4 / ARDUINO LEONARDO
+//
+// D0               PD2                 RXD1/INT2
+// D1               PD3                 TXD1/INT3
+// D2               PD1     SDA         SDA/INT1
+// D3#              PD0     PWM8/SCL    OC0B/SCL/INT0
+// D4       A6      PD4                 ADC8
+// D5#              PC6     ???         OC3A/#OC4A
+// D6#      A7      PD7     FastPWM     #OC4D/ADC10
+// D7               PE6                 INT6/AIN0
+//
+// D8       A8      PB4                 ADC11/PCINT4
+// D9#      A9      PB5     PWM16       OC1A/#OC4B/ADC12/PCINT5
+// D10#     A10     PB6     PWM16       OC1B/0c4B/ADC13/PCINT6
+// D11#             PB7     PWM8/16     0C0A/OC1C/#RTS/PCINT7
+// D12      A11     PD6                 T1/#OC4D/ADC9
+// D13#             PC7     PWM10       CLK0/OC4A
+//
+// A0       D18     PF7                 ADC7
+// A1       D19     PF6                 ADC6
+// A2       D20     PF5                 ADC5
+// A3       D21     PF4                 ADC4
+// A4       D22     PF1                 ADC1
+// A5       D23     PF0                 ADC0
+//
+// New pins D14..D17 to map SPI port to digital pins
+//
+// MISO     D14     PB3                 MISO,PCINT3
+// SCK      D15     PB1                 SCK,PCINT1
+// MOSI     D16     PB2                 MOSI,PCINT2
+// SS       D17     PB0                 RXLED,SS/PCINT0
+//
+// Connected LEDs on board for TX and RX
+// TXLED    D24     PD5                 XCK1
+// RXLED    D17     PB0
+// HWB              PE2                 HWB
+
+// these arrays map port names (e.g. port B) to the
+// appropriate addresses for various functions (e.g. reading
+// and writing)
+const uint16_t PROGMEM port_to_mode_PGM[] = {
+    NOT_A_PORT,
+    NOT_A_PORT,
+    (uint16_t) &DDRB,
+    (uint16_t) &DDRC,
+    (uint16_t) &DDRD,
+    (uint16_t) &DDRE,
+    (uint16_t) &DDRF,
+};
+
+const uint16_t PROGMEM port_to_output_PGM[] = {
+    NOT_A_PORT,
+    NOT_A_PORT,
+    (uint16_t) &PORTB,
+    (uint16_t) &PORTC,
+    (uint16_t) &PORTD,
+    (uint16_t) &PORTE,
+    (uint16_t) &PORTF,
+};
+
+const uint16_t PROGMEM port_to_input_PGM[] = {
+    NOT_A_PORT,
+    NOT_A_PORT,
+    (uint16_t) &PINB,
+    (uint16_t) &PINC,
+    (uint16_t) &PIND,
+    (uint16_t) &PINE,
+    (uint16_t) &PINF,
+};
+
+const uint8_t PROGMEM digital_pin_to_port_PGM[] = {
+    PD, // D0 - PD2
+    PD, // D1 - PD3
+    PD, // D2 - PD1
+    PD, // D3 - PD0
+    PD, // D4 - PD4
+    PC, // D5 - PC6
+    PD, // D6 - PD7
+    PE, // D7 - PE6
+
+    PB, // D8 - PB4
+    PB, // D9 - PB5
+    PB, // D10 - PB6
+    PB, // D11 - PB7
+    PD, // D12 - PD6
+    PC, // D13 - PC7
+
+    PB, // D14 - MISO - PB3
+    PB, // D15 - SCK - PB1
+    PB, // D16 - MOSI - PB2
+    PB, // D17 - SS - PB0
+
+    PF, // D18 - A0 - PF7
+    PF, // D19 - A1 - PF6
+    PF, // D20 - A2 - PF5
+    PF, // D21 - A3 - PF4
+    PF, // D22 - A4 - PF1
+    PF, // D23 - A5 - PF0
+
+    PD, // D24 - PD5
+    PD, // D25 / D6 - A7 - PD7
+    PB, // D26 / D8 - A8 - PB4
+    PB, // D27 / D9 - A9 - PB5
+    PB, // D28 / D10 - A10 - PB6
+    PD, // D29 / D12 - A11 - PD6
+};
+
+const uint8_t PROGMEM digital_pin_to_bit_mask_PGM[] = {
+    _BV(2), // D0 - PD2
+    _BV(3), // D1 - PD3
+    _BV(1), // D2 - PD1
+    _BV(0), // D3 - PD0
+    _BV(4), // D4 - PD4
+    _BV(6), // D5 - PC6
+    _BV(7), // D6 - PD7
+    _BV(6), // D7 - PE6
+
+    _BV(4), // D8 - PB4
+    _BV(5), // D9 - PB5
+    _BV(6), // D10 - PB6
+    _BV(7), // D11 - PB7
+    _BV(6), // D12 - PD6
+    _BV(7), // D13 - PC7
+
+    _BV(3), // D14 - MISO - PB3
+    _BV(1), // D15 - SCK - PB1
+    _BV(2), // D16 - MOSI - PB2
+    _BV(0), // D17 - SS - PB0
+
+    _BV(7), // D18 - A0 - PF7
+    _BV(6), // D19 - A1 - PF6
+    _BV(5), // D20 - A2 - PF5
+    _BV(4), // D21 - A3 - PF4
+    _BV(1), // D22 - A4 - PF1
+    _BV(0), // D23 - A5 - PF0
+
+    _BV(5), // D24 - PD5
+    _BV(7), // D25 / D6 - A7 - PD7
+    _BV(4), // D26 / D8 - A8 - PB4
+    _BV(5), // D27 / D9 - A9 - PB5
+    _BV(6), // D28 / D10 - A10 - PB6
+    _BV(6), // D29 / D12 - A11 - PD6
+};
+
+const uint8_t PROGMEM digital_pin_to_timer_PGM[] = {
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    TIMER0B,        /* 3 */
+    NOT_ON_TIMER,
+    TIMER3A,        /* 5 */
+    TIMER4D,        /* 6 */
+    NOT_ON_TIMER,
+
+    NOT_ON_TIMER,
+    TIMER1A,        /* 9 */
+    TIMER1B,        /* 10 */
+    TIMER0A,        /* 11 */
+
+    NOT_ON_TIMER,
+    TIMER4A,        /* 13 */
+
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+    NOT_ON_TIMER,
+};
+
+const uint8_t PROGMEM analog_pin_to_channel_PGM[] = {
+    7,  // A0               PF7                 ADC7
+    6,  // A1               PF6                 ADC6
+    5,  // A2               PF5                 ADC5
+    4,  // A3               PF4                 ADC4
+    1,  // A4               PF1                 ADC1
+    0,  // A5               PF0                 ADC0
+    8,  // A6       D4      PD4                 ADC8
+    10, // A7       D6      PD7                 ADC10
+    11, // A8       D8      PB4                 ADC11
+    12, // A9       D9      PB5                 ADC12
+    13, // A10      D10     PB6                 ADC13
+    9   // A11      D12     PD6                 ADC9
+};
+
+#endif /* ARDUINO_MAIN */
+
+// These serial port names are intended to allow libraries and architecture-neutral
+// sketches to automatically default to the correct port name for a particular type
+// of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+// the first hardware serial port whose RX/TX pins are not dedicated to another use.
+//
+// SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+//
+// SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+//
+// SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+//
+// SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+//
+// SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+//                            pins are NOT connected to anything by default.
+#define SERIAL_PORT_MONITOR        Serial
+#define SERIAL_PORT_USBVIRTUAL     Serial
+#define SERIAL_PORT_HARDWARE       Serial1
+#define SERIAL_PORT_HARDWARE_OPEN  Serial1
+
+#endif /* Pins_Arduino_h */

--- a/keyboards/atreus62/readme.md
+++ b/keyboards/atreus62/readme.md
@@ -1,0 +1,10 @@
+atreus62 keyboard firmware
+======================
+
+This firmware is for the atreus62 keyboard.
+
+This version utilizes a Pro Micro for its controller and has a 62 key layout.
+
+https://github.com/profet23/atreus62
+
+TODO: More information

--- a/keyboards/atreus62/rules.mk
+++ b/keyboards/atreus62/rules.mk
@@ -1,0 +1,66 @@
+
+# MCU name
+#MCU = at90usb1287
+MCU = atmega32u4
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+# Interrupt driven control endpoint task(+60)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
+
+
+# Boot Section Size in *bytes*
+#   Teensy halfKay   512
+#   Teensy++ halfKay 1024
+#   Atmel DFU loader 4096
+#   LUFA bootloader  4096
+#   USBaspLoader     2048
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+# Build Options
+#   change to "no" to disable the options, or define them in the Makefile in
+#   the appropriate keymap folder that will get included automatically
+#
+BOOTMAGIC_ENABLE ?= no       # Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE ?= yes       # Mouse keys(+4700)
+EXTRAKEY_ENABLE ?= yes       # Audio control and System control(+450)
+CONSOLE_ENABLE ?= yes         # Console for debug(+400)
+COMMAND_ENABLE ?= yes        # Commands for debug and configuration
+NKRO_ENABLE ?= no            # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
+#BACKLIGHT_ENABLE ?= no      # Enable keyboard backlight functionality
+#MIDI_ENABLE ?= no            # MIDI controls
+UNICODE_ENABLE ?= yes         # Unicode
+#BLUETOOTH_ENABLE ?= yes       # Enable Bluetooth with the Adafruit EZ-Key HID
+
+# Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
+SLEEP_LED_ENABLE ?= no    # Breathing sleep LED during USB suspend


### PR DESCRIPTION
Would like to add support for the atreus62 keyboard. It's an open source keyboard inspired by the original atreus.

Project here: https://github.com/profet23/atreus62

Pictures of builds/PCBs:  
![image](https://cloud.githubusercontent.com/assets/2411974/20376977/93b88c7a-ac59-11e6-8991-482020ad0a0b.png)

![image](https://cloud.githubusercontent.com/assets/2411974/20376989/a2fb1ad6-ac59-11e6-8e33-b353b896bd8a.png)



