### PR TITLE
Always initialize the Infinity Ergodox backlight

### DIFF
--- a/keyboards/ergodox/infinity/infinity.c
+++ b/keyboards/ergodox/infinity/infinity.c
@@ -38,7 +38,6 @@ void init_serial_link_hal(void) {
 // Using a higher pre-scalar without flicker is possible but FTM0_MOD will need to be reduced
 // Which will reduce the brightness range
 #define PRESCALAR_DEFINE 0
-#ifdef VISUALIZER_ENABLE
 void lcd_backlight_hal_init(void) {
 	// Setup Backlight
     SIM->SCGC6 |= SIM_SCGC6_FTM0;
@@ -76,7 +75,6 @@ void lcd_backlight_hal_color(uint16_t r, uint16_t g, uint16_t b) {
 	CHANNEL_GREEN.CnV = g;
 	CHANNEL_BLUE.CnV = b;
 }
-#endif
 
 __attribute__ ((weak))
 void matrix_init_user(void) {
@@ -92,6 +90,10 @@ void matrix_init_kb(void) {
 	// runs once when the firmware starts up
 
 	matrix_init_user();
+	// The backlight always has to be initialized, otherwise it will stay lit
+#ifndef VISUALIZER_ENABLE
+	lcd_backlight_hal_init();
+#endif
 }
 
 void matrix_scan_kb(void) {

--- a/keyboards/ergodox/infinity/led.c
+++ b/keyboards/ergodox/infinity/led.c
@@ -21,29 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 void led_set(uint8_t usb_led) {
-// The LCD backlight functionality conflicts with this simple
-// red backlight
-#if !defined(LCD_BACKLIGHT_ENABLE) && defined(STATUS_LED_ENABLE)
-    // PTC1: LCD Backlight Red(0:on/1:off)
-    GPIOC->PDDR |= (1<<1);
-    PORTC->PCR[1] |= PORTx_PCRn_DSE | PORTx_PCRn_MUX(1);
-    if (usb_led & (1<<USB_LED_CAPS_LOCK)) {
-        GPIOC->PCOR |= (1<<1);
-    } else {
-        GPIOC->PSOR |= (1<<1);
-    }
-#elif !defined(LCD_BACKLIGHT_ENABLE)
+    //TODO: Add led emulation if there's no customized visualization
     (void)usb_led;
-    GPIOC->PDDR |= (1<<1);
-    PORTC->PCR[1] |= PORTx_PCRn_DSE | PORTx_PCRn_MUX(1);
-    GPIOC->PSOR |= (1<<1);
-    GPIOC->PDDR |= (1<<2);
-    PORTC->PCR[2] |= PORTx_PCRn_DSE | PORTx_PCRn_MUX(1);
-    GPIOC->PSOR |= (1<<2);
-    GPIOC->PDDR |= (1<<3);
-    PORTC->PCR[3] |= PORTx_PCRn_DSE | PORTx_PCRn_MUX(1);
-    GPIOC->PSOR |= (1<<3);
-#else
-    (void)usb_led;
-#endif
 }


### PR DESCRIPTION
Otherwise it will stay lit. The set_led functionality is also disabled since it doesn't work properly for slaves.

This "fixes" #704, by making sure that neither of the LCD backlights stays on. The proper fix will come later when the full visualization works.