### PR TITLE
Set backlight status to on if it's at maximum brightness already and the brightness increase keybind is used

### DIFF
--- a/tmk_core/common/backlight.c
+++ b/tmk_core/common/backlight.c
@@ -36,9 +36,9 @@ void backlight_increase(void)
     if(backlight_config.level < BACKLIGHT_LEVELS)
     {
         backlight_config.level++;
-        backlight_config.enable = 1;
-        eeconfig_update_backlight(backlight_config.raw);
     }
+    backlight_config.enable = 1;
+    eeconfig_update_backlight(backlight_config.raw);
     dprintf("backlight increase: %u\n", backlight_config.level);
     backlight_set(backlight_config.level);
 }


### PR DESCRIPTION
Before it was turned on but the status wasn't set to on, so you had to
push the backlight toggle bind twice to turn it off again