### PR TITLE
Fixed NO_SUSPEND_POWER_DOWN handling

### DIFF
--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -113,11 +113,6 @@ __attribute__ ((weak)) void matrix_power_up(void) {}
 __attribute__ ((weak)) void matrix_power_down(void) {}
 bool suspend_wakeup_condition(void)
 {
-#ifdef BACKLIGHT_ENABLE
-#ifndef NO_SUSPEND_POWER_DOWN
-    backlight_set(0);
-#endif
-#endif
     matrix_power_up();
     matrix_scan();
     matrix_power_down();
@@ -135,7 +130,7 @@ void suspend_wakeup_init(void)
 #ifdef BACKLIGHT_ENABLE
     backlight_init();
 #endif
-led_set(host_keyboard_leds());
+	led_set(host_keyboard_leds());
 }
 
 #ifndef NO_SUSPEND_POWER_DOWN

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -47,6 +47,7 @@ void suspend_idle(uint8_t time)
     sleep_disable();
 }
 
+#ifndef NO_SUSPEND_POWER_DOWN
 /* Power down MCU with watchdog timer
  * wdto: watchdog timer timeout defined in <avr/wdt.h>
  *          WDTO_15MS
@@ -61,6 +62,7 @@ void suspend_idle(uint8_t time)
  *          WDTO_8S
  */
 static uint8_t wdt_timeout = 0;
+
 static void power_down(uint8_t wdto)
 {
 #ifdef PROTOCOL_LUFA
@@ -98,10 +100,13 @@ static void power_down(uint8_t wdto)
     // Disable watchdog after sleep
     wdt_disable();
 }
+#endif
 
 void suspend_power_down(void)
 {
+#ifndef NO_SUSPEND_POWER_DOWN
     power_down(WDTO_15MS);
+#endif
 }
 
 __attribute__ ((weak)) void matrix_power_up(void) {}
@@ -109,7 +114,9 @@ __attribute__ ((weak)) void matrix_power_down(void) {}
 bool suspend_wakeup_condition(void)
 {
 #ifdef BACKLIGHT_ENABLE
+#ifndef NO_SUSPEND_POWER_DOWN
     backlight_set(0);
+#endif
 #endif
     matrix_power_up();
     matrix_scan();
@@ -126,7 +133,6 @@ void suspend_wakeup_init(void)
     // clear keyboard state
     clear_keyboard();
 #ifdef BACKLIGHT_ENABLE
-    backlight_set(0);
     backlight_init();
 #endif
 led_set(host_keyboard_leds());


### PR DESCRIPTION
This fixes how NO_SUSPEND_POWER_DOWN was being used in suspend.c

Now it works as intended. If you don't want the AVR to go into power down sleep mode, and (for example) keep the backlight on while the keyboard is in USB suspend mode, then define NO_SUSPEND_POWER_DOWN in the Makefile.

If it's NOT defined, keyboards with backlight enabled will get a backlight_set(0) when going into suspend mode, and a backlight_init() when waking up, which should restore the backlight to the previous level (which was stored in EEPROM).

