### PR TITLE
Tidy up atomicity in timer.c and ring_buffer.h

### DIFF
--- a/tmk_core/common/avr/timer.c
+++ b/tmk_core/common/avr/timer.c
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <avr/io.h>
 #include <avr/interrupt.h>
+#include <util/atomic.h>
 #include <stdint.h>
 #include "timer_avr.h"
 #include "timer.h"
@@ -24,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // counter resolution 1ms
 // NOTE: union { uint32_t timer32; struct { uint16_t dummy; uint16_t timer16; }}
-volatile uint32_t timer_count = 0;
+volatile uint32_t timer_count;
 
 void timer_init(void)
 {
@@ -52,10 +53,9 @@ void timer_init(void)
 inline
 void timer_clear(void)
 {
-    uint8_t sreg = SREG;
-    cli();
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     timer_count = 0;
-    SREG = sreg;
+  }
 }
 
 inline
@@ -63,10 +63,9 @@ uint16_t timer_read(void)
 {
     uint32_t t;
 
-    uint8_t sreg = SREG;
-    cli();
-    t = timer_count;
-    SREG = sreg;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+      t = timer_count;
+    }
 
     return (t & 0xFFFF);
 }
@@ -76,10 +75,9 @@ uint32_t timer_read32(void)
 {
     uint32_t t;
 
-    uint8_t sreg = SREG;
-    cli();
-    t = timer_count;
-    SREG = sreg;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+      t = timer_count;
+    }
 
     return t;
 }
@@ -89,10 +87,9 @@ uint16_t timer_elapsed(uint16_t last)
 {
     uint32_t t;
 
-    uint8_t sreg = SREG;
-    cli();
-    t = timer_count;
-    SREG = sreg;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+      t = timer_count;
+    }
 
     return TIMER_DIFF_16((t & 0xFFFF), last);
 }
@@ -102,10 +99,9 @@ uint32_t timer_elapsed32(uint32_t last)
 {
     uint32_t t;
 
-    uint8_t sreg = SREG;
-    cli();
-    t = timer_count;
-    SREG = sreg;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+      t = timer_count;
+    }
 
     return TIMER_DIFF_32(t, last);
 }

--- a/tmk_core/ring_buffer.h
+++ b/tmk_core/ring_buffer.h
@@ -4,13 +4,13 @@
  * Ring buffer to store scan codes from keyboard
  *------------------------------------------------------------------*/
 #define RBUF_SIZE 32
+#include <util/atomic.h>
 static uint8_t rbuf[RBUF_SIZE];
 static uint8_t rbuf_head = 0;
 static uint8_t rbuf_tail = 0;
 static inline void rbuf_enqueue(uint8_t data)
 {
-    uint8_t sreg = SREG;
-    cli();
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     uint8_t next = (rbuf_head + 1) % RBUF_SIZE;
     if (next != rbuf_tail) {
         rbuf[rbuf_head] = data;
@@ -18,36 +18,34 @@ static inline void rbuf_enqueue(uint8_t data)
     } else {
         print("rbuf: full\n");
     }
-    SREG = sreg;
+  }
 }
 static inline uint8_t rbuf_dequeue(void)
 {
     uint8_t val = 0;
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
 
-    uint8_t sreg = SREG;
-    cli();
     if (rbuf_head != rbuf_tail) {
         val = rbuf[rbuf_tail];
         rbuf_tail = (rbuf_tail + 1) % RBUF_SIZE;
     }
-    SREG = sreg;
+  }
 
     return val;
 }
 static inline bool rbuf_has_data(void)
 {
-    uint8_t sreg = SREG;
-    cli();
-    bool has_data = (rbuf_head != rbuf_tail);
-    SREG = sreg;
-    return has_data;
+  bool has_data;
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+    has_data = (rbuf_head != rbuf_tail);
+  }
+  return has_data;
 }
 static inline void rbuf_clear(void)
 {
-    uint8_t sreg = SREG;
-    cli();
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     rbuf_head = rbuf_tail = 0;
-    SREG = sreg;
+  }
 }
 
 #endif  /* RING_BUFFER_H */


### PR DESCRIPTION
(this is part of a series relating to #912)

Adopt the macros for saving/restoring the interrupt state
that are provided by the avr gcc environment.

Removing intialization of the timer value; this shaves off
a few bytes because globals are default initialized to zero.