### PR TITLE
Add arduino-alike GPIO pin control helpers

### DIFF
--- a/quantum/pincontrol.h
+++ b/quantum/pincontrol.h
@@ -1,0 +1,37 @@
+#pragma once
+// Some helpers for controlling gpio pins
+#include <avr/io.h>
+
+enum {
+  PinDirectionInput = 0,
+  PinDirectionOutput = 1,
+  PinLevelHigh = 1,
+  PinLevelLow = 0,
+};
+
+// ex: pinMode(B0, PinDirectionOutput);
+static inline void pinMode(uint8_t pin, int mode) {
+  uint8_t bv = _BV(pin & 0xf);
+  if (mode == PinDirectionOutput) {
+    _SFR_IO8((pin >> 4) + 1) |= bv;
+  } else {
+    _SFR_IO8((pin >> 4) + 1) &= ~bv;
+    _SFR_IO8((pin >> 4) + 2) &= ~bv;
+  }
+}
+
+// ex: digitalWrite(B0, PinLevelHigh);
+static inline void digitalWrite(uint8_t pin, int mode) {
+  uint8_t bv = _BV(pin & 0xf);
+  if (mode == PinLevelHigh) {
+    _SFR_IO8((pin >> 4) + 2) |= bv;
+  } else {
+    _SFR_IO8((pin >> 4) + 2) &= ~bv;
+  }
+}
+
+// Return true if the pin is HIGH
+// digitalRead(B0)
+static inline bool digitalRead(uint8_t pin) {
+  return _SFR_IO8(pin >> 4) & _BV(pin & 0xf);
+}

--- a/tmk_core/common/avr/timer.c
+++ b/tmk_core/common/avr/timer.c
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <avr/io.h>
 #include <avr/interrupt.h>
+#include <util/atomic.h>
 #include <stdint.h>
 #include "timer_avr.h"
 #include "timer.h"
@@ -24,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // counter resolution 1ms
 // NOTE: union { uint32_t timer32; struct { uint16_t dummy; uint16_t timer16; }}
-volatile uint32_t timer_count = 0;
+volatile uint32_t timer_count;
 
 void timer_init(void)
 {
@@ -52,10 +53,9 @@ void timer_init(void)
 inline
 void timer_clear(void)
 {
-    uint8_t sreg = SREG;
-    cli();
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     timer_count = 0;
-    SREG = sreg;
+  }
 }
 
 inline
@@ -63,10 +63,9 @@ uint16_t timer_read(void)
 {
     uint32_t t;
 
-    uint8_t sreg = SREG;
-    cli();
-    t = timer_count;
-    SREG = sreg;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+      t = timer_count;
+    }
 
     return (t & 0xFFFF);
 }
@@ -76,10 +75,9 @@ uint32_t timer_read32(void)
 {
     uint32_t t;
 
-    uint8_t sreg = SREG;
-    cli();
-    t = timer_count;
-    SREG = sreg;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+      t = timer_count;
+    }
 
     return t;
 }
@@ -89,10 +87,9 @@ uint16_t timer_elapsed(uint16_t last)
 {
     uint32_t t;
 
-    uint8_t sreg = SREG;
-    cli();
-    t = timer_count;
-    SREG = sreg;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+      t = timer_count;
+    }
 
     return TIMER_DIFF_16((t & 0xFFFF), last);
 }
@@ -102,10 +99,9 @@ uint32_t timer_elapsed32(uint32_t last)
 {
     uint32_t t;
 
-    uint8_t sreg = SREG;
-    cli();
-    t = timer_count;
-    SREG = sreg;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+      t = timer_count;
+    }
 
     return TIMER_DIFF_32(t, last);
 }

--- a/tmk_core/ring_buffer.h
+++ b/tmk_core/ring_buffer.h
@@ -4,13 +4,13 @@
  * Ring buffer to store scan codes from keyboard
  *------------------------------------------------------------------*/
 #define RBUF_SIZE 32
+#include <util/atomic.h>
 static uint8_t rbuf[RBUF_SIZE];
 static uint8_t rbuf_head = 0;
 static uint8_t rbuf_tail = 0;
 static inline void rbuf_enqueue(uint8_t data)
 {
-    uint8_t sreg = SREG;
-    cli();
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     uint8_t next = (rbuf_head + 1) % RBUF_SIZE;
     if (next != rbuf_tail) {
         rbuf[rbuf_head] = data;
@@ -18,36 +18,34 @@ static inline void rbuf_enqueue(uint8_t data)
     } else {
         print("rbuf: full\n");
     }
-    SREG = sreg;
+  }
 }
 static inline uint8_t rbuf_dequeue(void)
 {
     uint8_t val = 0;
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
 
-    uint8_t sreg = SREG;
-    cli();
     if (rbuf_head != rbuf_tail) {
         val = rbuf[rbuf_tail];
         rbuf_tail = (rbuf_tail + 1) % RBUF_SIZE;
     }
-    SREG = sreg;
+  }
 
     return val;
 }
 static inline bool rbuf_has_data(void)
 {
-    uint8_t sreg = SREG;
-    cli();
-    bool has_data = (rbuf_head != rbuf_tail);
-    SREG = sreg;
-    return has_data;
+  bool has_data;
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+    has_data = (rbuf_head != rbuf_tail);
+  }
+  return has_data;
 }
 static inline void rbuf_clear(void)
 {
-    uint8_t sreg = SREG;
-    cli();
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     rbuf_head = rbuf_tail = 0;
-    SREG = sreg;
+  }
 }
 
 #endif  /* RING_BUFFER_H */


### PR DESCRIPTION
(this is part of a series relating to #912; it is stacked on top of #913, so there is apparently a duplicate commit here due to the lack of stacked diff review support on GH)

Unlike the arduino functions, these don't take abstract pin numbers,
they take pin labels like `B0`.  Also, rather than taking very
generic parameter names, these take slightly more descriptive
enum values.

These improve the clarity of code that would otherwise be inscrutable
bit manipulation in tersely named port register names.