### PR TITLE
Initial version of Raw HID interface

### DIFF
--- a/keyboards/planck/planck.c
+++ b/keyboards/planck/planck.c
@@ -1,5 +1,8 @@
 #include "planck.h"
 
+#include "raw_hid.h"
+#include "keymap.h"
+
 #ifdef ONEHAND_ENABLE
 __attribute__ ((weak))
 const keypos_t hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
@@ -17,3 +20,14 @@ void matrix_init_kb(void) {
 
 	matrix_init_user();
 }
+
+#ifdef RAW_ENABLE
+
+void raw_hid_receive( uint8_t *data, uint8_t length )
+{
+	// Basic test of Raw HID
+	// Echo back data received
+	raw_hid_send( data, length );
+}
+
+#endif

--- a/keyboards/planck/planck.c
+++ b/keyboards/planck/planck.c
@@ -1,8 +1,5 @@
 #include "planck.h"
 
-#include "raw_hid.h"
-#include "keymap.h"
-
 #ifdef ONEHAND_ENABLE
 __attribute__ ((weak))
 const keypos_t hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
@@ -20,14 +17,3 @@ void matrix_init_kb(void) {
 
 	matrix_init_user();
 }
-
-#ifdef RAW_ENABLE
-
-void raw_hid_receive( uint8_t *data, uint8_t length )
-{
-	// Basic test of Raw HID
-	// Echo back data received
-	raw_hid_send( data, length );
-}
-
-#endif

--- a/keyboards/planck/rules.mk
+++ b/keyboards/planck/rules.mk
@@ -62,8 +62,7 @@ AUDIO_ENABLE ?= no           # Audio output on port C6
 UNICODE_ENABLE ?= no         # Unicode
 BLUETOOTH_ENABLE ?= no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE ?= no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
-API_SYSEX_ENABLE = no
-RAW_ENABLE = yes
+API_SYSEX_ENABLE = yes
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE ?= no    # Breathing sleep LED during USB suspend

--- a/keyboards/planck/rules.mk
+++ b/keyboards/planck/rules.mk
@@ -62,7 +62,8 @@ AUDIO_ENABLE ?= no           # Audio output on port C6
 UNICODE_ENABLE ?= no         # Unicode
 BLUETOOTH_ENABLE ?= no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE ?= no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
-API_SYSEX_ENABLE = yes
+API_SYSEX_ENABLE = no
+RAW_ENABLE = yes
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE ?= no    # Breathing sleep LED during USB suspend

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -50,6 +50,10 @@ ifeq ($(strip $(EXTRAKEY_ENABLE)), yes)
     TMK_COMMON_DEFS += -DEXTRAKEY_ENABLE
 endif
 
+ifeq ($(strip $(RAW_ENABLE)), yes)
+    TMK_COMMON_DEFS += -DRAW_ENABLE
+endif
+
 ifeq ($(strip $(CONSOLE_ENABLE)), yes)
     TMK_COMMON_DEFS += -DCONSOLE_ENABLE
 else

--- a/tmk_core/common/raw_hid.h
+++ b/tmk_core/common/raw_hid.h
@@ -1,0 +1,8 @@
+#ifndef _RAW_HID_H_
+#define _RAW_HID_H_
+
+void raw_hid_receive( uint8_t *data, uint8_t length );
+
+void raw_hid_send( uint8_t *data, uint8_t length );
+
+#endif

--- a/tmk_core/protocol/lufa/descriptor.c
+++ b/tmk_core/protocol/lufa/descriptor.c
@@ -164,6 +164,28 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM ExtrakeyReport[] =
 };
 #endif
 
+#ifdef RAW_ENABLE
+const USB_Descriptor_HIDReport_Datatype_t PROGMEM RawReport[] =
+{
+    HID_RI_USAGE_PAGE(16, 0xFF60), /* Vendor Page 0xFF60 */
+    HID_RI_USAGE(8, 0x61), /* Vendor Usage 0x61 */
+    HID_RI_COLLECTION(8, 0x01), /* Application */
+        HID_RI_USAGE(8, 0x62), /* Vendor Usage 0x62 */
+        HID_RI_LOGICAL_MINIMUM(8, 0x00),
+        HID_RI_LOGICAL_MAXIMUM(16, 0x00FF),
+        HID_RI_REPORT_COUNT(8, RAW_EPSIZE),
+        HID_RI_REPORT_SIZE(8, 0x08),
+        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+        HID_RI_USAGE(8, 0x63), /* Vendor Usage 0x63 */
+        HID_RI_LOGICAL_MINIMUM(8, 0x00),
+        HID_RI_LOGICAL_MAXIMUM(16, 0x00FF),
+        HID_RI_REPORT_COUNT(8, RAW_EPSIZE),
+        HID_RI_REPORT_SIZE(8, 0x08),
+        HID_RI_OUTPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE | HID_IOF_NON_VOLATILE),
+    HID_RI_END_COLLECTION(0),
+};
+#endif
+
 #ifdef CONSOLE_ENABLE
 const USB_Descriptor_HIDReport_Datatype_t PROGMEM ConsoleReport[] =
 {
@@ -398,6 +420,58 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
             .PollingIntervalMS      = 0x0A
         },
 #endif
+
+		/*
+	     * Raw
+	     */
+	#ifdef RAW_ENABLE
+	    .Raw_Interface =
+	        {
+	            .Header                 = {.Size = sizeof(USB_Descriptor_Interface_t), .Type = DTYPE_Interface},
+
+	            .InterfaceNumber        = RAW_INTERFACE,
+	            .AlternateSetting       = 0x00,
+
+	            .TotalEndpoints         = 2,
+
+	            .Class                  = HID_CSCP_HIDClass,
+	            .SubClass               = HID_CSCP_NonBootSubclass,
+	            .Protocol               = HID_CSCP_NonBootProtocol,
+
+	            .InterfaceStrIndex      = NO_DESCRIPTOR
+	        },
+
+	    .Raw_HID =
+	        {
+	            .Header                 = {.Size = sizeof(USB_HID_Descriptor_HID_t), .Type = HID_DTYPE_HID},
+
+	            .HIDSpec                = VERSION_BCD(1,1,1),
+	            .CountryCode            = 0x00,
+	            .TotalReportDescriptors = 1,
+	            .HIDReportType          = HID_DTYPE_Report,
+	            .HIDReportLength        = sizeof(RawReport)
+	        },
+
+	    .Raw_INEndpoint =
+	        {
+	            .Header                 = {.Size = sizeof(USB_Descriptor_Endpoint_t), .Type = DTYPE_Endpoint},
+
+	            .EndpointAddress        = (ENDPOINT_DIR_IN | RAW_IN_EPNUM),
+	            .Attributes             = (EP_TYPE_INTERRUPT | ENDPOINT_ATTR_NO_SYNC | ENDPOINT_USAGE_DATA),
+	            .EndpointSize           = RAW_EPSIZE,
+	            .PollingIntervalMS      = 0x01
+	        },
+
+	    .Raw_OUTEndpoint =
+	        {
+	            .Header                 = {.Size = sizeof(USB_Descriptor_Endpoint_t), .Type = DTYPE_Endpoint},
+
+	            .EndpointAddress        = (ENDPOINT_DIR_OUT | RAW_OUT_EPNUM),
+	            .Attributes             = (EP_TYPE_INTERRUPT | ENDPOINT_ATTR_NO_SYNC | ENDPOINT_USAGE_DATA),
+	            .EndpointSize           = RAW_EPSIZE,
+	            .PollingIntervalMS      = 0x01
+	        },
+	#endif
 
     /*
      * Console
@@ -754,7 +828,6 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
                     .PollingIntervalMS      = 0x05
             },
 #endif
-
 };
 
 
@@ -846,6 +919,12 @@ uint16_t CALLBACK_USB_GetDescriptor(const uint16_t wValue,
                 Size    = sizeof(USB_HID_Descriptor_HID_t);
                 break;
 #endif
+#ifdef RAW_ENABLE
+            case RAW_INTERFACE:
+                Address = &ConfigurationDescriptor.Raw_HID;
+                Size    = sizeof(USB_HID_Descriptor_HID_t);
+                break;
+#endif
 #ifdef CONSOLE_ENABLE
             case CONSOLE_INTERFACE:
                 Address = &ConfigurationDescriptor.Console_HID;
@@ -876,6 +955,12 @@ uint16_t CALLBACK_USB_GetDescriptor(const uint16_t wValue,
             case EXTRAKEY_INTERFACE:
                 Address = &ExtrakeyReport;
                 Size    = sizeof(ExtrakeyReport);
+                break;
+#endif
+#ifdef RAW_ENABLE
+            case RAW_INTERFACE:
+                Address = &RawReport;
+                Size    = sizeof(RawReport);
                 break;
 #endif
 #ifdef CONSOLE_ENABLE

--- a/tmk_core/protocol/lufa/descriptor.h
+++ b/tmk_core/protocol/lufa/descriptor.h
@@ -71,6 +71,14 @@ typedef struct
     USB_Descriptor_Endpoint_t             Extrakey_INEndpoint;
 #endif
 
+#ifdef RAW_ENABLE
+    // Raw HID Interface
+    USB_Descriptor_Interface_t            Raw_Interface;
+    USB_HID_Descriptor_HID_t              Raw_HID;
+    USB_Descriptor_Endpoint_t             Raw_INEndpoint;
+    USB_Descriptor_Endpoint_t             Raw_OUTEndpoint;
+#endif
+
 #ifdef CONSOLE_ENABLE
     // Console HID Interface
     USB_Descriptor_Interface_t            Console_Interface;
@@ -137,10 +145,16 @@ typedef struct
 #   define EXTRAKEY_INTERFACE       MOUSE_INTERFACE
 #endif
 
-#ifdef CONSOLE_ENABLE
-#   define CONSOLE_INTERFACE        (EXTRAKEY_INTERFACE + 1)
+#ifdef RAW_ENABLE
+#   define RAW_INTERFACE        	(EXTRAKEY_INTERFACE + 1)
 #else
-#   define CONSOLE_INTERFACE        EXTRAKEY_INTERFACE
+#   define RAW_INTERFACE        	EXTRAKEY_INTERFACE
+#endif
+
+#ifdef CONSOLE_ENABLE
+#   define CONSOLE_INTERFACE        (RAW_INTERFACE + 1)
+#else
+#   define CONSOLE_INTERFACE        RAW_INTERFACE
 #endif
 
 #ifdef NKRO_ENABLE
@@ -182,12 +196,19 @@ typedef struct
 #   define EXTRAKEY_IN_EPNUM        MOUSE_IN_EPNUM
 #endif
 
-#ifdef CONSOLE_ENABLE
-#   define CONSOLE_IN_EPNUM         (EXTRAKEY_IN_EPNUM + 1)
-#   define CONSOLE_OUT_EPNUM        (EXTRAKEY_IN_EPNUM + 1)
-//#   define CONSOLE_OUT_EPNUM        (EXTRAKEY_IN_EPNUM + 2)
+#ifdef RAW_ENABLE
+#   define RAW_IN_EPNUM         (EXTRAKEY_IN_EPNUM + 1)
+#   define RAW_OUT_EPNUM        (EXTRAKEY_IN_EPNUM + 2)
 #else
-#   define CONSOLE_OUT_EPNUM        EXTRAKEY_IN_EPNUM
+#   define RAW_OUT_EPNUM        EXTRAKEY_IN_EPNUM
+#endif
+
+#ifdef CONSOLE_ENABLE
+#   define CONSOLE_IN_EPNUM         (RAW_OUT_EPNUM + 1)
+//#   define CONSOLE_OUT_EPNUM        (RAW_OUT_EPNUM + 2)
+#   define CONSOLE_OUT_EPNUM        (RAW_OUT_EPNUM + 1)
+#else
+#   define CONSOLE_OUT_EPNUM        RAW_OUT_EPNUM
 #endif
 
 #ifdef NKRO_ENABLE
@@ -217,7 +238,6 @@ typedef struct
 #   define CDC_OUT_EPNUM	MIDI_STREAM_OUT_EPNUM
 #endif
 
-
 #if defined(__AVR_ATmega32U2__) && CDC_OUT_EPNUM > 4
 # error "Endpoints are not available enough to support all functions. Remove some in Makefile.(MOUSEKEY, EXTRAKEY, CONSOLE, NKRO, MIDI, SERIAL)"
 #endif
@@ -225,6 +245,7 @@ typedef struct
 #define KEYBOARD_EPSIZE             8
 #define MOUSE_EPSIZE                8
 #define EXTRAKEY_EPSIZE             8
+#define RAW_EPSIZE              	32
 #define CONSOLE_EPSIZE              32
 #define NKRO_EPSIZE                 32
 #define MIDI_STREAM_EPSIZE          64


### PR DESCRIPTION
Before I go too far down the rabbit hole and start using this interface, I thought I'd get this pulled in for others to have a play.

Example usage in Planck shown, though you don't have to merge that in (or at least turn off `RAW_ENABLE` in the Makefile)

To send or receive data on the host, use something like http://www.signal11.us/oss/hidapi/
The `hidtest.cpp` is a good starting point for usage.
Call `hid_enumerate(0xFEED, 0x6060)` (or whatever you set your VID/PID to).
Iterate over `hid_device_info` linked list until you get one with the matching `usage_page` and `usage`

e.g.

```
	devs = hid_enumerate(0xFEED, 0x6060);
	cur_dev = devs;
	while (cur_dev) {
		if (cur_dev->usage_page == 0xFF60 &&
			cur_dev->usage == 0x0061)
		{
			// Find the first one that matches the usage page/usage.
			strcpy(path, cur_dev->path);
			break;
		}
		cur_dev = cur_dev->next;
	}
	hid_free_enumeration(devs);
```
Then you can call `handle = hid_open_path(path);`

`hid_write()` expects the first byte to be a report ID, so make your buffer 33 bytes and set first byte to zero.
