### PR TITLE
Adds warnings to Planck keymaps that exceed 0x7000 bytes in size #929

### DIFF
--- a/keyboards/planck/keymaps/jhenahan/Makefile
+++ b/keyboards/planck/keymaps/jhenahan/Makefile
@@ -1,4 +1,6 @@
-
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 # Build Options
 #   change to "no" to disable the options, or define them in the Makefile in 

--- a/keyboards/planck/keymaps/joe/Makefile
+++ b/keyboards/planck/keymaps/joe/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/leo/Makefile
+++ b/keyboards/planck/keymaps/leo/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/lucas/Makefile
+++ b/keyboards/planck/keymaps/lucas/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/mollat/Makefile
+++ b/keyboards/planck/keymaps/mollat/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/nico/Makefile
+++ b/keyboards/planck/keymaps/nico/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/premek/Makefile
+++ b/keyboards/planck/keymaps/premek/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/priyadi/Makefile
+++ b/keyboards/planck/keymaps/priyadi/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/pvc/Makefile
+++ b/keyboards/planck/keymaps/pvc/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 # Build Options
 #   change to "no" to disable the options, or define them in the Makefile in

--- a/keyboards/planck/keymaps/sgoodwin/Makefile
+++ b/keyboards/planck/keymaps/sgoodwin/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/tak3over/Makefile
+++ b/keyboards/planck/keymaps/tak3over/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/thermal_printer/Makefile
+++ b/keyboards/planck/keymaps/thermal_printer/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options

--- a/keyboards/planck/keymaps/vifon/Makefile
+++ b/keyboards/planck/keymaps/vifon/Makefile
@@ -1,3 +1,6 @@
+# Please remove if no longer applicable
+$(warning THIS FILE MAY BE TOO LARGE FOR YOUR KEYBOARD)
+$(warning Please disable some options in the Makefile to resolve)
 
 
 # Build Options


### PR DESCRIPTION
Also for issue #929, here are more warnings for additional keymaps.