### PR TITLE
The adafruit BLE C++ code requires -std=c++11

### DIFF
--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -26,7 +26,7 @@ CFLAGS += -fno-inline-small-functions
 CFLAGS += -fno-strict-aliasing
 
 CPPFLAGS += $(COMPILEFLAGS)
-CPPFLAGS += -fno-exceptions
+CPPFLAGS += -fno-exceptions -std=c++11
 
 LDFLAGS +=-Wl,--gc-sections
 


### PR DESCRIPTION
I'm not sure if this is the correct place to do this, but it works for me.