### PR TITLE
Allow power consumption to be set per-keyboard.

### DIFF
--- a/keyboards/ergodox/ez/config.h
+++ b/keyboards/ergodox/ez/config.h
@@ -56,6 +56,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE    5
 
+#define USB_MAX_POWER_CONSUMPTION 50
+
 /*
  * Feature disable options
  *  These options are also useful to firmware size reduction.

--- a/tmk_core/protocol/lufa/descriptor.c
+++ b/tmk_core/protocol/lufa/descriptor.c
@@ -40,6 +40,9 @@
 #include "report.h"
 #include "descriptor.h"
 
+#ifndef USB_MAX_POWER_CONSUMPTION
+#define USB_MAX_POWER_CONSUMPTION 500
+#endif
 
 /*******************************************************************************
  * HID Report Descriptors
@@ -294,7 +297,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 
             .ConfigAttributes       = (USB_CONFIG_ATTR_RESERVED | USB_CONFIG_ATTR_REMOTEWAKEUP),
 
-            .MaxPowerConsumption    = USB_CONFIG_POWER_MA(500)
+            .MaxPowerConsumption    = USB_CONFIG_POWER_MA(USB_MAX_POWER_CONSUMPTION)
         },
 
     /*


### PR DESCRIPTION
Based on discussion in #954.

This worked for me locally with my Ergodox EZ, which now happily acts as an input device for an iPad Mini 4.

![](https://www.dropbox.com/s/syy13ec71m4sukl/Screenshot%202016-12-14%2023.37.13.png?dl=1)