### PR TITLE
Fixes issue #900 KC_PWR not working

### DIFF
--- a/tmk_core/protocol/lufa/descriptor.c
+++ b/tmk_core/protocol/lufa/descriptor.c
@@ -143,10 +143,10 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM ExtrakeyReport[] =
     HID_RI_USAGE(8, 0x80), /* System Control */
     HID_RI_COLLECTION(8, 0x01), /* Application */
         HID_RI_REPORT_ID(8, REPORT_ID_SYSTEM),
-        HID_RI_LOGICAL_MINIMUM(16, 0x0081),
-        HID_RI_LOGICAL_MAXIMUM(16, 0x00B7),
+        HID_RI_LOGICAL_MINIMUM(16, 0x0001),
+        HID_RI_LOGICAL_MAXIMUM(16, 0x0003),
         HID_RI_USAGE_MINIMUM(16, 0x0081), /* System Power Down */
-        HID_RI_USAGE_MAXIMUM(16, 0x00B7), /* System Display LCD Autoscale */
+        HID_RI_USAGE_MAXIMUM(16, 0x0083), /* System Wake Up */
         HID_RI_REPORT_SIZE(8, 16),
         HID_RI_REPORT_COUNT(8, 1),
         HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_ARRAY | HID_IOF_ABSOLUTE),

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -732,7 +732,7 @@ static void send_system(uint16_t data)
 
     report_extra_t r = {
         .report_id = REPORT_ID_SYSTEM,
-        .usage = data
+        .usage = data - SYSTEM_POWER_DOWN + 1
     };
     Endpoint_SelectEndpoint(EXTRAKEY_IN_EPNUM);
 


### PR DESCRIPTION
This fixes #900 which was broken with the fix for #522.

I've limited the "usage" range to the only three "usage" codes in the source. The data being sent needs to be a 1-based index to the "array" of states, hence the "logical" min/max of 1..3.

Well, that's how I'm interpreting the HID spec: **http://www.usb.org/developers/hidpage/HID1_11.pdf** page 32:

> The value returned by an Array item is an index so it is recommended that:
> 1) An Array field returns a 0 value when no controls in the array are asserted.
> 2) The Logical Minimum equals 1.
> 3) The Logical Maximum equal the number of elements in the array. 

