### PR TITLE
Fixed bug in do_code16

### DIFF
--- a/quantum/keymap.h
+++ b/quantum/keymap.h
@@ -53,6 +53,7 @@ enum quantum_keycodes {
     QK_LSFT               = 0x0200,
     QK_LALT               = 0x0400,
     QK_LGUI               = 0x0800,
+    QK_RMODS_MIN          = 0x1000,
     QK_RCTL               = 0x1100,
     QK_RSFT               = 0x1200,
     QK_RALT               = 0x1400,

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -21,6 +21,8 @@ static void do_code16 (uint16_t code, void (*f) (uint8_t)) {
   if (code & QK_LGUI)
     f(KC_LGUI);
 
+  if (code < QK_RMODS_MIN) return;
+
   if (code & QK_RCTL)
     f(KC_RCTL);
   if (code & QK_RSFT)


### PR DESCRIPTION
The do_code16 function would falsely send both right and left modifiers for a given keycode because of the way the keycode is checked against the modifiers (bitwise and). 
See #865 for an example where this matters.