### PR TITLE
ergodox: Update algernon's keymap to v1.10

### DIFF
--- a/keyboards/ergodox/keymaps/algernon/NEWS.md
+++ b/keyboards/ergodox/keymaps/algernon/NEWS.md
@@ -1,5 +1,19 @@
 <!-- -*- mode: markdown; fill-column: 8192 -*- -->
 
+## v1.10
+
+*2016-12-28*
+
+### Miscellaneous
+
+* `µ` can now be entered with UCIS.
+* `™` can now be entered with UCIS.
+
+### Tools
+
+* `tools/hid-commands` can now find Banshee, and prefers it over Kodi.
+* `tools/hid-commands` can now find Chrome too, not juts Chromium.
+
 ## v1.9
 
 *2016-10-16*

--- a/keyboards/ergodox/keymaps/algernon/keymap.c
+++ b/keyboards/ergodox/keymaps/algernon/keymap.c
@@ -96,8 +96,6 @@ enum {
 
 uint16_t gui_timer = 0;
 
-uint16_t kf_timers[12];
-
 #if KEYLOGGER_ENABLE
 # ifdef AUTOLOG_ENABLE
 bool log_enable = true;
@@ -786,7 +784,7 @@ static void ang_tap_dance_tmux_pane_select (qk_tap_dance_state_t *state, void *u
   if (state->count >= 2) {
     kc = KC_Z;
   }
-  
+
   register_code(KC_LALT);
   register_code(KC_SPC);
   unregister_code(KC_SPC);
@@ -1040,7 +1038,9 @@ const qk_ucis_symbol_t ucis_symbol_table[] = UCIS_TABLE
  UCIS_SYM("heart", 0x2764),
  UCIS_SYM("bolt", 0x26a1),
  UCIS_SYM("pi", 0x03c0),
- UCIS_SYM("mouse", 0x1f401)
+ UCIS_SYM("mouse", 0x1f401),
+ UCIS_SYM("micro", 0x00b5),
+ UCIS_SYM("tm", 0x2122)
 );
 
 bool process_record_user (uint16_t keycode, keyrecord_t *record) {

--- a/keyboards/ergodox/keymaps/algernon/tools/hid-commands
+++ b/keyboards/ergodox/keymaps/algernon/tools/hid-commands
@@ -16,7 +16,8 @@ _cmd_appsel () {
 }
 
 cmd_appsel_music () {
-    wmctrl -x -a rhythmbox || wmctrl -x -a spotify || wmctrl -x -a kodi || true
+    wmctrl -x -a rhythmbox || wmctrl -x -a spotify || \
+        wmctrl -x -a banshee || wmctrl -x -a kodi || true
     xdotool key Escape
 }
 
@@ -33,7 +34,7 @@ cmd_appsel_term () {
 }
 
 cmd_appsel_chrome () {
-    _cmd_appsel chromium
+    _cmd_appsel chrom
 }
 
 cmd_appsel_start () {


### PR DESCRIPTION
Miscellaneous
=============

* `µ` can now be entered with UCIS.
* `™` can now be entered with UCIS.

Tools
=====

* `tools/hid-commands` can now find Banshee, and prefers it over Kodi.
* `tools/hid-commands` can now find Chrome too, not juts Chromium.