### PR TITLE
Add extern for 'led' global, set 'weak' attribute for rgblight_set()

### DIFF
--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -370,6 +370,7 @@ void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b) {
   rgblight_set();
 }
 
++__attribute__ ((weak))
 void rgblight_set(void) {
   if (rgblight_config.enable) {
     #ifdef RGBW

--- a/quantum/rgblight.c
+++ b/quantum/rgblight.c
@@ -370,7 +370,7 @@ void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b) {
   rgblight_set();
 }
 
-+__attribute__ ((weak))
+__attribute__ ((weak))
 void rgblight_set(void) {
   if (rgblight_config.enable) {
     #ifdef RGBW

--- a/quantum/rgblight.h
+++ b/quantum/rgblight.h
@@ -40,6 +40,8 @@
 #include "eeconfig.h"
 #include "light_ws2812.h"
 
+extern LED_TYPE led[RGBLED_NUM];
+
 extern const uint8_t RGBLED_BREATHING_INTERVALS[4] PROGMEM;
 extern const uint8_t RGBLED_RAINBOW_MOOD_INTERVALS[3] PROGMEM;
 extern const uint8_t RGBLED_RAINBOW_SWIRL_INTERVALS[3] PROGMEM;


### PR DESCRIPTION
With 'rgblight_set()' to be overridden, all of the RGB lighting code can be re-used for other hardware implementations.

Working with the LFK78 keyboard definition at https://github.com/mechkeys/qmk_firmware.