### PR TITLE
Adds SCMD and SCMD_T

### DIFF
--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -159,6 +159,7 @@ enum quantum_keycodes {
 #define MEH(kc)  (kc | QK_LCTL | QK_LSFT | QK_LALT)
 #define LCAG(kc) (kc | QK_LCTL | QK_LALT | QK_LGUI)
 #define ALTG(kc) (kc | QK_RCTL | QK_RALT)
+#define SCMD(kc) (kc | QK_LGUI | QK_LSFT)
 
 #define MOD_HYPR 0xf
 #define MOD_MEH 0x7
@@ -293,6 +294,7 @@ enum quantum_keycodes {
 #define MEH_T(kc) MT((MOD_LCTL | MOD_LSFT | MOD_LALT), kc) // Meh is a less hyper version of the Hyper key -- doesn't include Win or Cmd, so just alt+shift+ctrl
 #define LCAG_T(kc) MT((MOD_LCTL | MOD_LALT | MOD_LGUI), kc) // Left control alt and gui
 #define ALL_T(kc) MT((MOD_LCTL | MOD_LSFT | MOD_LALT | MOD_LGUI), kc) // see http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/
+#define SCMD_T(kc) MT((MOD_LGUI | MOD_LSFT), kc)
 
 // Dedicated keycode versions for Hyper and Meh, if you want to use them as standalone keys rather than mod-tap
 #define KC_HYPR HYPR(KC_NO)

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -160,7 +160,7 @@ enum quantum_keycodes {
 #define LCAG(kc) (kc | QK_LCTL | QK_LALT | QK_LGUI)
 #define ALTG(kc) (kc | QK_RCTL | QK_RALT)
 #define SCMD(kc) (kc | QK_LGUI | QK_LSFT)
-#define SWIN SCMD
+#define SWIN(kc) SCMD(kc)
 
 #define MOD_HYPR 0xf
 #define MOD_MEH 0x7
@@ -296,7 +296,7 @@ enum quantum_keycodes {
 #define LCAG_T(kc) MT((MOD_LCTL | MOD_LALT | MOD_LGUI), kc) // Left control alt and gui
 #define ALL_T(kc) MT((MOD_LCTL | MOD_LSFT | MOD_LALT | MOD_LGUI), kc) // see http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/
 #define SCMD_T(kc) MT((MOD_LGUI | MOD_LSFT), kc)
-#define SWIN_T SCMD_T
+#define SWIN_T(kc) SCMD_T(kc)
 
 // Dedicated keycode versions for Hyper and Meh, if you want to use them as standalone keys rather than mod-tap
 #define KC_HYPR HYPR(KC_NO)

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -160,6 +160,7 @@ enum quantum_keycodes {
 #define LCAG(kc) (kc | QK_LCTL | QK_LALT | QK_LGUI)
 #define ALTG(kc) (kc | QK_RCTL | QK_RALT)
 #define SCMD(kc) (kc | QK_LGUI | QK_LSFT)
+#define SWIN SCMD
 
 #define MOD_HYPR 0xf
 #define MOD_MEH 0x7
@@ -295,6 +296,7 @@ enum quantum_keycodes {
 #define LCAG_T(kc) MT((MOD_LCTL | MOD_LALT | MOD_LGUI), kc) // Left control alt and gui
 #define ALL_T(kc) MT((MOD_LCTL | MOD_LSFT | MOD_LALT | MOD_LGUI), kc) // see http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/
 #define SCMD_T(kc) MT((MOD_LGUI | MOD_LSFT), kc)
+#define SWIN_T SCMD_T
 
 // Dedicated keycode versions for Hyper and Meh, if you want to use them as standalone keys rather than mod-tap
 #define KC_HYPR HYPR(KC_NO)


### PR DESCRIPTION
This PR adds `SCMD` which stands for `Shift + Cmd`, and its corresponding `SCMD_T` (for dual-function keys).

The reason I went with `SCMD` and not `SGUI` for the name, is that this is mainly useful on a Mac, where Shift + Cmd bindings are common (Windows doesn't really have a ton of Shift + Win + something bindings, and I don't think Linux does either).

Thoughts?