### PR TITLE
Support for ps2avrGB / winkeyless.kr boards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os: linux
 dist: trusty
 sudo: required
 language: c
-compiler: avr-gcc
 branches:
   except:
     - /^.*-automated-build$/
@@ -12,13 +11,18 @@ env:
   matrix:
   - TARGET=all-keyboards AUTOGEN=true
   - TARGET=test AUTOGEN=false
+before_install:
+  - wget http://www.atmel.com/images/avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
+install:
+  - tar -zxf avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
+  - export PATH="$PATH:$TRAVIS_BUILD_DIR/avr8-gnu-toolchain-linux_x86_64/bin"
+before_script:
+  - avr-gcc --version
 script:
 - make $TARGET AUTOGEN=$AUTOGEN
 addons:
   apt:
     packages:
-    - avr-libc
-    - gcc-avr
     - dfu-programmer
     - pandoc
     - gcc-arm-none-eabi

--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -221,7 +221,11 @@ OPT_DEFS += $(TMK_COMMON_DEFS)
 EXTRALDFLAGS += $(TMK_COMMON_LDFLAGS)
 
 ifeq ($(PLATFORM),AVR)
+ifeq ($(strip $(PROTOCOL)), VUSB)
+	include $(TMK_PATH)/protocol/vusb.mk
+else
 	include $(TMK_PATH)/protocol/lufa.mk
+endif
 	include $(TMK_PATH)/avr.mk
 endif
 

--- a/keyboards/ps2avrGB/Makefile
+++ b/keyboards/ps2avrGB/Makefile
@@ -1,0 +1,3 @@
+ifndef MAKEFILE_INCLUDED
+	include ../../Makefile
+endif

--- a/keyboards/ps2avrGB/README.md
+++ b/keyboards/ps2avrGB/README.md
@@ -1,0 +1,61 @@
+ps2avrGB keyboard firmware
+==========================
+
+This is a port of the QMK firmware for boards that are based on the
+ps2avrGB firmware, like the [ps2avrGB
+keyboard](https://www.keyclack.com/product/gb-ps2avrgb/) or the ones sold
+by [Winkeyless](http://winkeyless.kr/product/ps2avrgb-parts/).
+
+Note that this is a complete replacement for the firmware, so you won't be
+using Bootmapper Client to change any keyboard settings, since not all the
+USB report options are supported.
+
+## Supported Boards
+
+Only the [B.mini X2](http://winkeyless.kr/product/b-mini-x2-pcb/) has been
+tested so far (since it's the only one I own). But other boards that use
+the ps2avrGB firmware should work as well.
+
+## Installing
+
+First, install the requirements. These commands are for OSX, but all you
+need is the AVR toolchain and `bootloadHID` for flashing:
+
+```
+$ brew cask install crosspack-avr
+$ brew install --HEAD https://raw.githubusercontent.com/robertgzr/homebrew-tap/master/bootloadhid.rb
+```
+
+In order to use the `./program` script, which can reboot the board into
+the bootloader, you'll need Python 2 with PyUSB installed:
+
+```
+$ pip install pyusb
+```
+
+Then, with the keyboard plugged in, simply run this command from the
+`qmk_firmware` directory:
+
+```
+$ make ps2avrGB-program
+```
+
+If you prefer, you can just build it and flash the firmware directly with
+`bootloadHID` if you boot the board while holding down `L_Ctrl` to keep it
+in the bootloader:
+
+```
+$ make ps2avrGB
+$ bootloadHID -r ps2avrGB_default.hex
+```
+
+## Troubleshooting
+
+From my experience, it's really hard to brick these boards. But these
+tricks have been useful when it got stuck in a weird scenario.
+
+1. Try plugging the board in while pressing `L_Ctrl`. This will force it
+   to boot only the bootloader without loading the firmware. Once this is
+   done, just reflash the board with the original firmware.
+2. Sometimes USB hubs can act weird, so try connecting the board directly
+   to your computer or plugging/unplugging the USB hub.

--- a/keyboards/ps2avrGB/config.h
+++ b/keyboards/ps2avrGB/config.h
@@ -29,10 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 8
 #define MATRIX_COLS 15
 
-/* only support one hard-coded backlight color for now */
-#define BACKLIGHT_LEVELS 0
-#define BACKLIGHT_COLOR 0x110000
-
 #define NO_UART 1
 #define BOOTLOADHID_BOOTLOADER 1
 

--- a/keyboards/ps2avrGB/config.h
+++ b/keyboards/ps2avrGB/config.h
@@ -1,0 +1,44 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "config_common.h"
+
+#define VENDOR_ID       0x20A0
+#define PRODUCT_ID      0x422D
+// TODO: share these strings with usbconfig.h
+// Edit usbconfig.h to change these.
+#define MANUFACTURER    winkeyless.kr
+#define PRODUCT         ps2avrGB
+
+/* matrix size */
+#define MATRIX_ROWS 8
+#define MATRIX_COLS 15
+
+/* only support one hard-coded backlight color for now */
+#define BACKLIGHT_LEVELS 0
+#define BACKLIGHT_COLOR 0x110000
+
+#define NO_UART 1
+#define EEPROM_BOOTLOADER_START 1
+
+/* key combination for command */
+#define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))
+
+#endif

--- a/keyboards/ps2avrGB/config.h
+++ b/keyboards/ps2avrGB/config.h
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include "config_common.h"
-
 #define VENDOR_ID       0x20A0
 #define PRODUCT_ID      0x422D
 // TODO: share these strings with usbconfig.h

--- a/keyboards/ps2avrGB/config.h
+++ b/keyboards/ps2avrGB/config.h
@@ -34,7 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_COLOR 0x110000
 
 #define NO_UART 1
-#define EEPROM_BOOTLOADER_START 1
+#define BOOTLOADHID_BOOTLOADER 1
 
 /* key combination for command */
 #define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))

--- a/keyboards/ps2avrGB/keymaps/default/keymap.c
+++ b/keyboards/ps2avrGB/keymaps/default/keymap.c
@@ -1,3 +1,20 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include "ps2avrGB.h"
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {

--- a/keyboards/ps2avrGB/keymaps/default/keymap.c
+++ b/keyboards/ps2avrGB/keymaps/default/keymap.c
@@ -2,33 +2,14 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KEYMAP( \
-        ESC, NO,  NO,  NO,  NO,  NO,  NO,  MPRV,MPLY,MNXT,MUTE,VOLD,VOLU,PSCR,HOME,END, \
+        ESC, F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12, PSCR,HOME,END, \
         GRV, 1,   2,   3,   4,   5,   6,   7,   8,   9,   0,   MINS,EQL, BSPC,     DEL, \
-        TAB, Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P,   LBRC,RBRC,BSLS,     FN1, \
-        FN2, A,   S,   D,   F,   G,   H,   J,   K,   L,   SCLN,QUOT,ENT,           PGUP,\
+        TAB, Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P,   LBRC,RBRC,BSLS,     INS, \
+        CAPS,A,   S,   D,   F,   G,   H,   J,   K,   L,   SCLN,QUOT,ENT,           PGUP,\
         LSFT,Z,   X,   C,   V,   B,   N,   M,   COMM,DOT, SLSH,RSFT,          UP,  PGDN,\
-        FN0, LALT,LGUI,          SPC,                     RGUI,RALT,RCTL,LEFT,DOWN,RGHT \
-    ),
-    KEYMAP( \
-        NO,  F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12, NO,  NO,  NO,  \
-        NO,  NO,  NO,  NO,  NO,  NO,  NO,  MPRV,MPLY,MNXT,MUTE,VOLD,VOLU,DEL,      NO,  \
-        NO,  NO,  NO,  NO,  NO,  NO,  NO,  PGUP,NO,  NO,  NO,  NO,  NO,  NO,       TRNS,\
-        FN2, NO,  NO,  PGDN,NO,  NO,  LEFT,DOWN,UP,  RGHT,NO,  NO,  NO,            NO,  \
-        TRNS,NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  TRNS,          NO,  NO,  \
-        TRNS,TRNS,TRNS,          NO,                      TRNS,TRNS,TRNS,NO,  NO,  NO   \
-    ),
-    KEYMAP( \
-        NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  \
-        NO,  NO,  NO,  NO,  END, NO,  NO,  NO,  NO,  NO,  HOME,NO,  NO,  NO,       NO,  \
-        NO,  BTN1,MS_U,BTN2,NO,  NO,  NO,  PGUP,FN1, NO,  NO,  NO,  NO,  NO,       TRNS,\
-        FN2, MS_L,MS_D,MS_R,NO,  NO,  LEFT,DOWN,UP,  RGHT,NO,  NO,  NO,            NO,  \
-        TRNS,NO,  DEL, NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  TRNS,          NO,  NO,  \
-        TRNS,TRNS,TRNS,          NO,                      TRNS,TRNS,TRNS,NO,  NO,  NO   \
+        LCTL,LALT,LGUI,          SPC,                     RGUI,RALT,RCTL,LEFT,DOWN,RGHT \
     ),
 };
 
 const uint16_t PROGMEM fn_actions[] = {
-    [0] = ACTION_LAYER_MOMENTARY(1),
-    [1] = ACTION_LAYER_TOGGLE(2),
-    [2] = ACTION_MODS_TAP_KEY(MOD_LCTL, KC_ESC),
 };

--- a/keyboards/ps2avrGB/keymaps/default/keymap.c
+++ b/keyboards/ps2avrGB/keymaps/default/keymap.c
@@ -1,0 +1,34 @@
+#include "ps2avrGB.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    KEYMAP( \
+        ESC, NO,  NO,  NO,  NO,  NO,  NO,  MPRV,MPLY,MNXT,MUTE,VOLD,VOLU,PSCR,HOME,END, \
+        GRV, 1,   2,   3,   4,   5,   6,   7,   8,   9,   0,   MINS,EQL, BSPC,     DEL, \
+        TAB, Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P,   LBRC,RBRC,BSLS,     FN1, \
+        FN2, A,   S,   D,   F,   G,   H,   J,   K,   L,   SCLN,QUOT,ENT,           PGUP,\
+        LSFT,Z,   X,   C,   V,   B,   N,   M,   COMM,DOT, SLSH,RSFT,          UP,  PGDN,\
+        FN0, LALT,LGUI,          SPC,                     RGUI,RALT,RCTL,LEFT,DOWN,RGHT \
+    ),
+    KEYMAP( \
+        NO,  F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12, NO,  NO,  NO,  \
+        NO,  NO,  NO,  NO,  NO,  NO,  NO,  MPRV,MPLY,MNXT,MUTE,VOLD,VOLU,DEL,      NO,  \
+        NO,  NO,  NO,  NO,  NO,  NO,  NO,  PGUP,NO,  NO,  NO,  NO,  NO,  NO,       TRNS,\
+        FN2, NO,  NO,  PGDN,NO,  NO,  LEFT,DOWN,UP,  RGHT,NO,  NO,  NO,            NO,  \
+        TRNS,NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  TRNS,          NO,  NO,  \
+        TRNS,TRNS,TRNS,          NO,                      TRNS,TRNS,TRNS,NO,  NO,  NO   \
+    ),
+    KEYMAP( \
+        NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  \
+        NO,  NO,  NO,  NO,  END, NO,  NO,  NO,  NO,  NO,  HOME,NO,  NO,  NO,       NO,  \
+        NO,  BTN1,MS_U,BTN2,NO,  NO,  NO,  PGUP,FN1, NO,  NO,  NO,  NO,  NO,       TRNS,\
+        FN2, MS_L,MS_D,MS_R,NO,  NO,  LEFT,DOWN,UP,  RGHT,NO,  NO,  NO,            NO,  \
+        TRNS,NO,  DEL, NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  TRNS,          NO,  NO,  \
+        TRNS,TRNS,TRNS,          NO,                      TRNS,TRNS,TRNS,NO,  NO,  NO   \
+    ),
+};
+
+const uint16_t PROGMEM fn_actions[] = {
+    [0] = ACTION_LAYER_MOMENTARY(1),
+    [1] = ACTION_LAYER_TOGGLE(2),
+    [2] = ACTION_MODS_TAP_KEY(MOD_LCTL, KC_ESC),
+};

--- a/keyboards/ps2avrGB/matrix.c
+++ b/keyboards/ps2avrGB/matrix.c
@@ -100,6 +100,5 @@ inline matrix_row_t matrix_get_row(uint8_t row) {
     return matrix[row];
 }
 
-void matrix_print(void)
-{
+void matrix_print(void) {
 }

--- a/keyboards/ps2avrGB/matrix.c
+++ b/keyboards/ps2avrGB/matrix.c
@@ -1,0 +1,105 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <avr/io.h>
+#include <util/delay.h>
+
+#include "matrix.h"
+
+#ifndef DEBOUNCE
+#   define DEBOUNCE	5
+#endif
+
+static uint8_t debouncing = DEBOUNCE;
+
+static matrix_row_t matrix[MATRIX_ROWS];
+static matrix_row_t matrix_debouncing[MATRIX_ROWS];
+
+void matrix_init(void) {
+    // all outputs for rows high
+    DDRB = 0xFF;
+    PORTB = 0xFF;
+    // all inputs for columns
+    DDRA = 0x00;
+    DDRC &= ~(0x111111<<2);
+    DDRD &= ~(1<<PIND7);
+    // all columns are pulled-up
+    PORTA = 0xFF;
+    PORTC |= (0b111111<<2);
+    PORTD |= (1<<PIND7);
+
+    // initialize matrix state: all keys off
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        matrix[row] = 0x00;
+        matrix_debouncing[row] = 0x00;
+    }
+}
+
+void matrix_set_row_status(uint8_t row) {
+    DDRB = (1 << row);
+    PORTB = ~(1 << row);
+}
+
+uint8_t bit_reverse(uint8_t x) {
+    x = ((x >> 1) & 0x55) | ((x << 1) & 0xaa);
+    x = ((x >> 2) & 0x33) | ((x << 2) & 0xcc);
+    x = ((x >> 4) & 0x0f) | ((x << 4) & 0xf0);
+    return x;
+}
+
+uint8_t matrix_scan(void) {
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        matrix_set_row_status(row);
+        _delay_us(5);
+
+        matrix_row_t cols = (
+            // cols 0..7, PORTA 0 -> 7
+            (~PINA) & 0xFF
+        ) | (
+            // cols 8..13, PORTC 7 -> 0
+            bit_reverse((~PINC) & 0xFF) << 8
+        ) | (
+            // col 14, PORTD 7
+            ((~PIND) & (1 << PIND7)) << 7
+        );
+
+        if (matrix_debouncing[row] != cols) {
+            matrix_debouncing[row] = cols;
+            debouncing = DEBOUNCE;
+        }
+    }
+
+    if (debouncing) {
+        if (--debouncing) {
+            _delay_ms(1);
+        } else {
+            for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+                matrix[i] = matrix_debouncing[i];
+            }
+        }
+    }
+
+    return 1;
+}
+
+inline matrix_row_t matrix_get_row(uint8_t row) {
+    return matrix[row];
+}
+
+void matrix_print(void)
+{
+}

--- a/keyboards/ps2avrGB/program
+++ b/keyboards/ps2avrGB/program
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function
+
+import os
+import sys
+import time
+import usb
+
+if len(sys.argv) < 2:
+    print('Usage: %s <firmware.hex>' % sys.argv[0])
+    sys.exit(1)
+
+print('Searching for ps2avrGB... ', end='')
+
+dev = usb.core.find(idVendor=0x20A0, idProduct=0x422D)
+if dev is None:
+    raise ValueError('Device not found')
+
+print('Found', end='\n\n')
+
+print('Device Information:')
+print('  idVendor: %d (0x%04x)' % (dev.idVendor, dev.idVendor))
+print('  idProduct: %d (0x%04x)' % (dev.idProduct, dev.idProduct))
+print('Manufacturer: %s' % (dev.iManufacturer))
+print('Serial: %s' % (dev.iSerialNumber))
+print('Product: %s' % (dev.iProduct), end='\n\n')
+
+print('Transferring control to bootloader... ', end='')
+
+dev.set_configuration()
+
+request_type = usb.util.build_request_type(
+        usb.util.CTRL_OUT,
+        usb.util.CTRL_TYPE_CLASS,
+        usb.util.CTRL_RECIPIENT_DEVICE)
+
+USBRQ_HID_SET_REPORT = 0x09
+HID_REPORT_OPTION = 0x0301
+
+
+try:
+    dev.ctrl_transfer(
+            request_type,
+            USBRQ_HID_SET_REPORT,
+            HID_REPORT_OPTION,
+            0,
+            [0, 0, 0xFF] + [0] * 5
+            )
+except usb.core.USBError:
+    # for some reason I keep getting USBError, but it works!
+    pass
+
+# wait a bit until bootloader starts up
+time.sleep(2)
+
+print('OK')
+print('Programming...')
+if os.system('bootloadHID -r "%s"' % sys.argv[1]) == 0:
+    print('\nDone!')

--- a/keyboards/ps2avrGB/ps2avrGB.h
+++ b/keyboards/ps2avrGB/ps2avrGB.h
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef KEYMAP_COMMON_H
+#define KEYMAP_COMMON_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "keycode.h"
+#include "action.h"
+#include "action_code.h"
+#include "action_layer.h"
+#include "action_macro.h"
+#include "action_util.h"
+#include "report.h"
+#include "host.h"
+#include "print.h"
+#include "debug.h"
+#include "keymap.h"
+
+
+#define KEYMAP( \
+    K05, K25, K35, K45, K55, K06, KA6, KA7, K07, KB5, KC5, KD5, KE5, KD1, KE1, KE2, \
+    K04, K14, K24, K34, K44, K54, K16, KB6, KB7, K17, KA4, KB4, KC4, KE4,      KD0, \
+    K03, K13, K23, K33, K43, K53, K26, KC6, KC7, K27, KA3, KB3, KC3, KD3,      K67, \
+    K02, K12, K22, K32, K42, K52, K36, KD6, KD7, K37, KA2, KB2, KD2,           KE0, \
+    K01, K11, K21, K31, K41, K51, K46, KE6, KE7, K47, KA1, KB1,           K86, K77, \
+    K00, K10, K20,           K56,                     K57, KB0, KC0, K66, K76, K96  \
+) \
+{ \
+    { KC_##K00, KC_##K10, KC_##K20, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KB0, KC_##KC0, KC_##KD0, KC_##KE0 }, \
+    { KC_##K01, KC_##K11, KC_##K21, KC_##K31, KC_##K41, KC_##K51, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KA1, KC_##KB1, KC_NO,    KC_##KD1, KC_##KE1 }, \
+    { KC_##K02, KC_##K12, KC_##K22, KC_##K32, KC_##K42, KC_##K52, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KA2, KC_##KB2, KC_NO,    KC_##KD2, KC_##KE2 }, \
+    { KC_##K03, KC_##K13, KC_##K23, KC_##K33, KC_##K43, KC_##K53, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KA3, KC_##KB3, KC_##KC3, KC_##KD3, KC_NO    }, \
+    { KC_##K04, KC_##K14, KC_##K24, KC_##K34, KC_##K44, KC_##K54, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KA4, KC_##KB4, KC_##KC4, KC_NO,    KC_##KE4 }, \
+    { KC_##K05, KC_NO,    KC_##K25, KC_##K35, KC_##K45, KC_##K55, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KB5, KC_##KC5, KC_##KD5, KC_##KE5 }, \
+    { KC_##K06, KC_##K16, KC_##K26, KC_##K36, KC_##K46, KC_##K56, KC_##K66, KC_##K76, KC_##K86, KC_##K96, KC_##KA6, KC_##KB6, KC_##KC6, KC_##KD6, KC_##KE6 }, \
+    { KC_##K07, KC_##K17, KC_##K27, KC_##K37, KC_##K47, KC_##K57, KC_##K67, KC_##K77, KC_NO,    KC_NO,    KC_##KA7, KC_##KB7, KC_##KC7, KC_##KD7, KC_##KE7 }  \
+}
+
+#endif

--- a/keyboards/ps2avrGB/ps2avrGB.h
+++ b/keyboards/ps2avrGB/ps2avrGB.h
@@ -17,20 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef KEYMAP_COMMON_H
 #define KEYMAP_COMMON_H
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "keycode.h"
 #include "action.h"
-#include "action_code.h"
-#include "action_layer.h"
-#include "action_macro.h"
-#include "action_util.h"
-#include "report.h"
-#include "host.h"
-#include "print.h"
-#include "debug.h"
-#include "keymap.h"
-
 
 #define KEYMAP( \
     K05, K25, K35, K45, K55, K06, KA6, KA7, K07, KB5, KC5, KD5, KE5, KD1, KE1, KE2, \

--- a/keyboards/ps2avrGB/ps2avrGB.h
+++ b/keyboards/ps2avrGB/ps2avrGB.h
@@ -14,6 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #ifndef KEYMAP_COMMON_H
 #define KEYMAP_COMMON_H
 

--- a/keyboards/ps2avrGB/rules.mk
+++ b/keyboards/ps2avrGB/rules.mk
@@ -1,0 +1,38 @@
+# MCU name
+MCU = atmega32a
+
+PROTOCOL = VUSB
+
+# disable UART since atmega32a apparently doesn't have it
+NO_UART = yes
+# this simplifies things for now
+NO_SUSPEND_POWER_DOWN = yes
+
+# Processor frequency.
+#   Normally the first thing your program should do is set the clock prescaler,
+#   so your program will run at the correct speed.  You should also set this
+#   variable to same clock speed.  The _delay_ms() macro uses this, and many
+#   examples use this variable to calculate timings.  Do not add a "UL" here.
+F_CPU = 12000000
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = yes  # Virtual DIP switch configuration
+MOUSEKEY_ENABLE = yes   # Mouse keys
+EXTRAKEY_ENABLE = yes   # Audio control and System control
+CONSOLE_ENABLE = yes    # Console for debug
+COMMAND_ENABLE = yes    # Commands for debug and configuration
+#BACKLIGHT_ENABLE = yes
+
+# V-USB debug level: To use ps2_usart.c level must be 0
+# ps2_usart.c requires USART to receive PS/2 signal.
+OPT_DEFS = -DDEBUG_LEVEL=0
+OPS_DEFS += -DPROTOCOL_VUSB
+OPT_DEFS += -DBOOTLOADER_SIZE=2048
+
+CUSTOM_MATRIX = yes
+SRC = matrix.c
+
+#---------------- Programming Options --------------------------
+PROGRAM_CMD = ./keyboards/ps2avrGB/program $(TARGET).hex

--- a/keyboards/ps2avrGB/rules.mk
+++ b/keyboards/ps2avrGB/rules.mk
@@ -1,38 +1,43 @@
+# Copyright 2017 Luiz Ribeiro <luizribeiro@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # MCU name
 MCU = atmega32a
-
 PROTOCOL = VUSB
 
-# disable UART since atmega32a apparently doesn't have it
+# unsupported features for now
 NO_UART = yes
-# this simplifies things for now
 NO_SUSPEND_POWER_DOWN = yes
+BACKLIGHT_ENABLE = no
 
-# Processor frequency.
-#   Normally the first thing your program should do is set the clock prescaler,
-#   so your program will run at the correct speed.  You should also set this
-#   variable to same clock speed.  The _delay_ms() macro uses this, and many
-#   examples use this variable to calculate timings.  Do not add a "UL" here.
+# processor frequency
 F_CPU = 12000000
 
-# Build Options
-#   comment out to disable the options.
-#
-BOOTMAGIC_ENABLE = yes  # Virtual DIP switch configuration
-MOUSEKEY_ENABLE = yes   # Mouse keys
-EXTRAKEY_ENABLE = yes   # Audio control and System control
-CONSOLE_ENABLE = yes    # Console for debug
-COMMAND_ENABLE = yes    # Commands for debug and configuration
-#BACKLIGHT_ENABLE = yes
+# build options
+BOOTMAGIC_ENABLE = yes
+MOUSEKEY_ENABLE = yes
+EXTRAKEY_ENABLE = yes
+CONSOLE_ENABLE = yes
+COMMAND_ENABLE = yes
 
-# V-USB debug level: To use ps2_usart.c level must be 0
-# ps2_usart.c requires USART to receive PS/2 signal.
 OPT_DEFS = -DDEBUG_LEVEL=0
-OPS_DEFS += -DPROTOCOL_VUSB
 OPT_DEFS += -DBOOTLOADER_SIZE=2048
 
+# custom matrix setup
 CUSTOM_MATRIX = yes
 SRC = matrix.c
 
-#---------------- Programming Options --------------------------
+# programming options
 PROGRAM_CMD = ./keyboards/ps2avrGB/program $(TARGET).hex

--- a/keyboards/ps2avrGB/usbconfig.h
+++ b/keyboards/ps2avrGB/usbconfig.h
@@ -1,0 +1,396 @@
+/* Name: usbconfig.h
+ * Project: V-USB, virtual USB port for Atmel's(r) AVR(r) microcontrollers
+ * Author: Christian Starkjohann
+ * Creation Date: 2005-04-01
+ * Tabsize: 4
+ * Copyright: (c) 2005 by OBJECTIVE DEVELOPMENT Software GmbH
+ * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
+ * This Revision: $Id: usbconfig-prototype.h 785 2010-05-30 17:57:07Z cs $
+ */
+
+#ifndef __usbconfig_h_included__
+#define __usbconfig_h_included__
+
+#include "config.h"
+
+/*
+General Description:
+This file is an example configuration (with inline documentation) for the USB
+driver. It configures V-USB for USB D+ connected to Port D bit 2 (which is
+also hardware interrupt 0 on many devices) and USB D- to Port D bit 4. You may
+wire the lines to any other port, as long as D+ is also wired to INT0 (or any
+other hardware interrupt, as long as it is the highest level interrupt, see
+section at the end of this file).
+*/
+
+/* ---------------------------- Hardware Config ---------------------------- */
+
+#define USB_CFG_IOPORTNAME      D
+/* This is the port where the USB bus is connected. When you configure it to
+ * "B", the registers PORTB, PINB and DDRB will be used.
+ */
+#define USB_CFG_DMINUS_BIT      3
+/* This is the bit number in USB_CFG_IOPORT where the USB D- line is connected.
+ * This may be any bit in the port.
+ */
+#define USB_CFG_DPLUS_BIT       2
+/* This is the bit number in USB_CFG_IOPORT where the USB D+ line is connected.
+ * This may be any bit in the port. Please note that D+ must also be connected
+ * to interrupt pin INT0! [You can also use other interrupts, see section
+ * "Optional MCU Description" below, or you can connect D- to the interrupt, as
+ * it is required if you use the USB_COUNT_SOF feature. If you use D- for the
+ * interrupt, the USB interrupt will also be triggered at Start-Of-Frame
+ * markers every millisecond.]
+ */
+#define USB_CFG_CLOCK_KHZ       (F_CPU/1000)
+/* Clock rate of the AVR in kHz. Legal values are 12000, 12800, 15000, 16000,
+ * 16500, 18000 and 20000. The 12.8 MHz and 16.5 MHz versions of the code
+ * require no crystal, they tolerate +/- 1% deviation from the nominal
+ * frequency. All other rates require a precision of 2000 ppm and thus a
+ * crystal!
+ * Since F_CPU should be defined to your actual clock rate anyway, you should
+ * not need to modify this setting.
+ */
+#define USB_CFG_CHECK_CRC       0
+/* Define this to 1 if you want that the driver checks integrity of incoming
+ * data packets (CRC checks). CRC checks cost quite a bit of code size and are
+ * currently only available for 18 MHz crystal clock. You must choose
+ * USB_CFG_CLOCK_KHZ = 18000 if you enable this option.
+ */
+
+/* ----------------------- Optional Hardware Config ------------------------ */
+
+/* #define USB_CFG_PULLUP_IOPORTNAME   D */
+/* If you connect the 1.5k pullup resistor from D- to a port pin instead of
+ * V+, you can connect and disconnect the device from firmware by calling
+ * the macros usbDeviceConnect() and usbDeviceDisconnect() (see usbdrv.h).
+ * This constant defines the port on which the pullup resistor is connected.
+ */
+/* #define USB_CFG_PULLUP_BIT          4 */
+/* This constant defines the bit number in USB_CFG_PULLUP_IOPORT (defined
+ * above) where the 1.5k pullup resistor is connected. See description
+ * above for details.
+ */
+
+/* --------------------------- Functional Range ---------------------------- */
+
+#define USB_CFG_HAVE_INTRIN_ENDPOINT    1
+/* Define this to 1 if you want to compile a version with two endpoints: The
+ * default control endpoint 0 and an interrupt-in endpoint (any other endpoint
+ * number).
+ */
+#define USB_CFG_HAVE_INTRIN_ENDPOINT3   1
+/* Define this to 1 if you want to compile a version with three endpoints: The
+ * default control endpoint 0, an interrupt-in endpoint 3 (or the number
+ * configured below) and a catch-all default interrupt-in endpoint as above.
+ * You must also define USB_CFG_HAVE_INTRIN_ENDPOINT to 1 for this feature.
+ */
+#define USB_CFG_EP3_NUMBER              3
+/* If the so-called endpoint 3 is used, it can now be configured to any other
+ * endpoint number (except 0) with this macro. Default if undefined is 3.
+ */
+/* #define USB_INITIAL_DATATOKEN           USBPID_DATA1 */
+/* The above macro defines the startup condition for data toggling on the
+ * interrupt/bulk endpoints 1 and 3. Defaults to USBPID_DATA1.
+ * Since the token is toggled BEFORE sending any data, the first packet is
+ * sent with the oposite value of this configuration!
+ */
+#define USB_CFG_IMPLEMENT_HALT          0
+/* Define this to 1 if you also want to implement the ENDPOINT_HALT feature
+ * for endpoint 1 (interrupt endpoint). Although you may not need this feature,
+ * it is required by the standard. We have made it a config option because it
+ * bloats the code considerably.
+ */
+#define USB_CFG_SUPPRESS_INTR_CODE      0
+/* Define this to 1 if you want to declare interrupt-in endpoints, but don't
+ * want to send any data over them. If this macro is defined to 1, functions
+ * usbSetInterrupt() and usbSetInterrupt3() are omitted. This is useful if
+ * you need the interrupt-in endpoints in order to comply to an interface
+ * (e.g. HID), but never want to send any data. This option saves a couple
+ * of bytes in flash memory and the transmit buffers in RAM.
+ */
+#define USB_CFG_INTR_POLL_INTERVAL      1
+/* If you compile a version with endpoint 1 (interrupt-in), this is the poll
+ * interval. The value is in milliseconds and must not be less than 10 ms for
+ * low speed devices.
+ */
+#define USB_CFG_IS_SELF_POWERED         0
+/* Define this to 1 if the device has its own power supply. Set it to 0 if the
+ * device is powered from the USB bus.
+ */
+#define USB_CFG_MAX_BUS_POWER           500
+/* Set this variable to the maximum USB bus power consumption of your device.
+ * The value is in milliamperes. [It will be divided by two since USB
+ * communicates power requirements in units of 2 mA.]
+ */
+#define USB_CFG_IMPLEMENT_FN_WRITE      1
+/* Set this to 1 if you want usbFunctionWrite() to be called for control-out
+ * transfers. Set it to 0 if you don't need it and want to save a couple of
+ * bytes.
+ */
+#define USB_CFG_IMPLEMENT_FN_READ       0
+/* Set this to 1 if you need to send control replies which are generated
+ * "on the fly" when usbFunctionRead() is called. If you only want to send
+ * data from a static buffer, set it to 0 and return the data from
+ * usbFunctionSetup(). This saves a couple of bytes.
+ */
+#define USB_CFG_IMPLEMENT_FN_WRITEOUT   0
+/* Define this to 1 if you want to use interrupt-out (or bulk out) endpoints.
+ * You must implement the function usbFunctionWriteOut() which receives all
+ * interrupt/bulk data sent to any endpoint other than 0. The endpoint number
+ * can be found in 'usbRxToken'.
+ */
+#define USB_CFG_HAVE_FLOWCONTROL        0
+/* Define this to 1 if you want flowcontrol over USB data. See the definition
+ * of the macros usbDisableAllRequests() and usbEnableAllRequests() in
+ * usbdrv.h.
+ */
+#define USB_CFG_DRIVER_FLASH_PAGE       0
+/* If the device has more than 64 kBytes of flash, define this to the 64 k page
+ * where the driver's constants (descriptors) are located. Or in other words:
+ * Define this to 1 for boot loaders on the ATMega128.
+ */
+#define USB_CFG_LONG_TRANSFERS          0
+/* Define this to 1 if you want to send/receive blocks of more than 254 bytes
+ * in a single control-in or control-out transfer. Note that the capability
+ * for long transfers increases the driver size.
+ */
+/* #define USB_RX_USER_HOOK(data, len)     if(usbRxToken == (uchar)USBPID_SETUP) blinkLED(); */
+/* This macro is a hook if you want to do unconventional things. If it is
+ * defined, it's inserted at the beginning of received message processing.
+ * If you eat the received message and don't want default processing to
+ * proceed, do a return after doing your things. One possible application
+ * (besides debugging) is to flash a status LED on each packet.
+ */
+/* #define USB_RESET_HOOK(resetStarts)     if(!resetStarts){hadUsbReset();} */
+/* This macro is a hook if you need to know when an USB RESET occurs. It has
+ * one parameter which distinguishes between the start of RESET state and its
+ * end.
+ */
+/* #define USB_SET_ADDRESS_HOOK()              hadAddressAssigned(); */
+/* This macro (if defined) is executed when a USB SET_ADDRESS request was
+ * received.
+ */
+#define USB_COUNT_SOF                   1
+/* define this macro to 1 if you need the global variable "usbSofCount" which
+ * counts SOF packets. This feature requires that the hardware interrupt is
+ * connected to D- instead of D+.
+ */
+/* #ifdef __ASSEMBLER__
+ * macro myAssemblerMacro
+ *     in      YL, TCNT0
+ *     sts     timer0Snapshot, YL
+ *     endm
+ * #endif
+ * #define USB_SOF_HOOK                    myAssemblerMacro
+ * This macro (if defined) is executed in the assembler module when a
+ * Start Of Frame condition is detected. It is recommended to define it to
+ * the name of an assembler macro which is defined here as well so that more
+ * than one assembler instruction can be used. The macro may use the register
+ * YL and modify SREG. If it lasts longer than a couple of cycles, USB messages
+ * immediately after an SOF pulse may be lost and must be retried by the host.
+ * What can you do with this hook? Since the SOF signal occurs exactly every
+ * 1 ms (unless the host is in sleep mode), you can use it to tune OSCCAL in
+ * designs running on the internal RC oscillator.
+ * Please note that Start Of Frame detection works only if D- is wired to the
+ * interrupt, not D+. THIS IS DIFFERENT THAN MOST EXAMPLES!
+ */
+#define USB_CFG_CHECK_DATA_TOGGLING     0
+/* define this macro to 1 if you want to filter out duplicate data packets
+ * sent by the host. Duplicates occur only as a consequence of communication
+ * errors, when the host does not receive an ACK. Please note that you need to
+ * implement the filtering yourself in usbFunctionWriteOut() and
+ * usbFunctionWrite(). Use the global usbCurrentDataToken and a static variable
+ * for each control- and out-endpoint to check for duplicate packets.
+ */
+#define USB_CFG_HAVE_MEASURE_FRAME_LENGTH   0
+/* define this macro to 1 if you want the function usbMeasureFrameLength()
+ * compiled in. This function can be used to calibrate the AVR's RC oscillator.
+ */
+#define USB_USE_FAST_CRC                0
+/* The assembler module has two implementations for the CRC algorithm. One is
+ * faster, the other is smaller. This CRC routine is only used for transmitted
+ * messages where timing is not critical. The faster routine needs 31 cycles
+ * per byte while the smaller one needs 61 to 69 cycles. The faster routine
+ * may be worth the 32 bytes bigger code size if you transmit lots of data and
+ * run the AVR close to its limit.
+ */
+
+/* -------------------------- Device Description --------------------------- */
+
+#define USB_CFG_VENDOR_ID       (VENDOR_ID & 0xFF), ((VENDOR_ID >> 8) & 0xFF)
+/* USB vendor ID for the device, low byte first. If you have registered your
+ * own Vendor ID, define it here. Otherwise you may use one of obdev's free
+ * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
+ * *** IMPORTANT NOTE ***
+ * This template uses obdev's shared VID/PID pair for Vendor Class devices
+ * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
+ * the implications!
+ */
+#define USB_CFG_DEVICE_ID       (PRODUCT_ID & 0xFF), ((PRODUCT_ID >> 8) & 0xFF)
+/* This is the ID of the product, low byte first. It is interpreted in the
+ * scope of the vendor ID. If you have registered your own VID with usb.org
+ * or if you have licensed a PID from somebody else, define it here. Otherwise
+ * you may use one of obdev's free shared VID/PID pairs. See the file
+ * USB-IDs-for-free.txt for details!
+ * *** IMPORTANT NOTE ***
+ * This template uses obdev's shared VID/PID pair for Vendor Class devices
+ * with libusb: 0x16c0/0x5dc.  Use this VID/PID pair ONLY if you understand
+ * the implications!
+ */
+#define USB_CFG_DEVICE_VERSION  0x00, 0x02
+/* Version number of the device: Minor number first, then major number.
+ */
+#define USB_CFG_VENDOR_NAME     'w', 'i', 'n', 'k', 'e', 'y', 'l', 'e', 's', 's', '.', 'k', 'r'
+#define USB_CFG_VENDOR_NAME_LEN 13
+/* These two values define the vendor name returned by the USB device. The name
+ * must be given as a list of characters under single quotes. The characters
+ * are interpreted as Unicode (UTF-16) entities.
+ * If you don't want a vendor name string, undefine these macros.
+ * ALWAYS define a vendor name containing your Internet domain name if you use
+ * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
+ * details.
+ */
+#define USB_CFG_DEVICE_NAME     'p', 's', '2', 'a', 'v', 'r', 'G', 'B'
+#define USB_CFG_DEVICE_NAME_LEN 8
+/* Same as above for the device name. If you don't want a device name, undefine
+ * the macros. See the file USB-IDs-for-free.txt before you assign a name if
+ * you use a shared VID/PID.
+ */
+/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
+/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
+/* Same as above for the serial number. If you don't want a serial number,
+ * undefine the macros.
+ * It may be useful to provide the serial number through other means than at
+ * compile time. See the section about descriptor properties below for how
+ * to fine tune control over USB descriptors such as the string descriptor
+ * for the serial number.
+ */
+#define USB_CFG_DEVICE_CLASS        0
+#define USB_CFG_DEVICE_SUBCLASS     0
+/* See USB specification if you want to conform to an existing device class.
+ * Class 0xff is "vendor specific".
+ */
+#define USB_CFG_INTERFACE_CLASS     3   /* HID */
+#define USB_CFG_INTERFACE_SUBCLASS  1   /* Boot */
+#define USB_CFG_INTERFACE_PROTOCOL  1   /* Keyboard */
+/* See USB specification if you want to conform to an existing device class or
+ * protocol. The following classes must be set at interface level:
+ * HID class is 3, no subclass and protocol required (but may be useful!)
+ * CDC class is 2, use subclass 2 and protocol 1 for ACM
+ */
+#define USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    0
+/* Define this to the length of the HID report descriptor, if you implement
+ * an HID device. Otherwise don't define it or define it to 0.
+ * If you use this define, you must add a PROGMEM character array named
+ * "usbHidReportDescriptor" to your code which contains the report descriptor.
+ * Don't forget to keep the array and this define in sync!
+ */
+
+/* #define USB_PUBLIC static */
+/* Use the define above if you #include usbdrv.c instead of linking against it.
+ * This technique saves a couple of bytes in flash memory.
+ */
+
+/* ------------------- Fine Control over USB Descriptors ------------------- */
+/* If you don't want to use the driver's default USB descriptors, you can
+ * provide our own. These can be provided as (1) fixed length static data in
+ * flash memory, (2) fixed length static data in RAM or (3) dynamically at
+ * runtime in the function usbFunctionDescriptor(). See usbdrv.h for more
+ * information about this function.
+ * Descriptor handling is configured through the descriptor's properties. If
+ * no properties are defined or if they are 0, the default descriptor is used.
+ * Possible properties are:
+ *   + USB_PROP_IS_DYNAMIC: The data for the descriptor should be fetched
+ *     at runtime via usbFunctionDescriptor(). If the usbMsgPtr mechanism is
+ *     used, the data is in FLASH by default. Add property USB_PROP_IS_RAM if
+ *     you want RAM pointers.
+ *   + USB_PROP_IS_RAM: The data returned by usbFunctionDescriptor() or found
+ *     in static memory is in RAM, not in flash memory.
+ *   + USB_PROP_LENGTH(len): If the data is in static memory (RAM or flash),
+ *     the driver must know the descriptor's length. The descriptor itself is
+ *     found at the address of a well known identifier (see below).
+ * List of static descriptor names (must be declared PROGMEM if in flash):
+ *   char usbDescriptorDevice[];
+ *   char usbDescriptorConfiguration[];
+ *   char usbDescriptorHidReport[];
+ *   char usbDescriptorString0[];
+ *   int usbDescriptorStringVendor[];
+ *   int usbDescriptorStringDevice[];
+ *   int usbDescriptorStringSerialNumber[];
+ * Other descriptors can't be provided statically, they must be provided
+ * dynamically at runtime.
+ *
+ * Descriptor properties are or-ed or added together, e.g.:
+ * #define USB_CFG_DESCR_PROPS_DEVICE   (USB_PROP_IS_RAM | USB_PROP_LENGTH(18))
+ *
+ * The following descriptors are defined:
+ *   USB_CFG_DESCR_PROPS_DEVICE
+ *   USB_CFG_DESCR_PROPS_CONFIGURATION
+ *   USB_CFG_DESCR_PROPS_STRINGS
+ *   USB_CFG_DESCR_PROPS_STRING_0
+ *   USB_CFG_DESCR_PROPS_STRING_VENDOR
+ *   USB_CFG_DESCR_PROPS_STRING_PRODUCT
+ *   USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER
+ *   USB_CFG_DESCR_PROPS_HID
+ *   USB_CFG_DESCR_PROPS_HID_REPORT
+ *   USB_CFG_DESCR_PROPS_UNKNOWN (for all descriptors not handled by the driver)
+ *
+ * Note about string descriptors: String descriptors are not just strings, they
+ * are Unicode strings prefixed with a 2 byte header. Example:
+ * int  serialNumberDescriptor[] = {
+ *     USB_STRING_DESCRIPTOR_HEADER(6),
+ *     'S', 'e', 'r', 'i', 'a', 'l'
+ * };
+ */
+
+#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_CONFIGURATION           USB_PROP_IS_DYNAMIC
+//#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
+#define USB_CFG_DESCR_PROPS_STRINGS                 0
+#define USB_CFG_DESCR_PROPS_STRING_0                0
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_HID                     USB_PROP_IS_DYNAMIC
+//#define USB_CFG_DESCR_PROPS_HID                     0
+#define USB_CFG_DESCR_PROPS_HID_REPORT              USB_PROP_IS_DYNAMIC
+//#define USB_CFG_DESCR_PROPS_HID_REPORT              0
+#define USB_CFG_DESCR_PROPS_UNKNOWN                 0
+
+#define usbMsgPtr_t unsigned short
+/* If usbMsgPtr_t is not defined, it defaults to 'uchar *'. We define it to
+ * a scalar type here because gcc generates slightly shorter code for scalar
+ * arithmetics than for pointer arithmetics. Remove this define for backward
+ * type compatibility or define it to an 8 bit type if you use data in RAM only
+ * and all RAM is below 256 bytes (tiny memory model in IAR CC).
+ */
+
+/* ----------------------- Optional MCU Description ------------------------ */
+
+/* The following configurations have working defaults in usbdrv.h. You
+ * usually don't need to set them explicitly. Only if you want to run
+ * the driver on a device which is not yet supported or with a compiler
+ * which is not fully supported (such as IAR C) or if you use a differnt
+ * interrupt than INT0, you may have to define some of these.
+ */
+/* #define USB_INTR_CFG            MCUCR */
+/* #define USB_INTR_CFG_SET        ((1 << ISC00) | (1 << ISC01)) */
+/* #define USB_INTR_CFG_CLR        0 */
+/* #define USB_INTR_ENABLE         GIMSK */
+/* #define USB_INTR_ENABLE_BIT     INT0 */
+/* #define USB_INTR_PENDING        GIFR */
+/* #define USB_INTR_PENDING_BIT    INTF0 */
+/* #define USB_INTR_VECTOR         INT0_vect */
+
+/* Set INT1 for D- falling edge to count SOF */
+/* #define USB_INTR_CFG            EICRA */
+#define USB_INTR_CFG_SET        ((1 << ISC11) | (0 << ISC10))
+/* #define USB_INTR_CFG_CLR        0 */
+/* #define USB_INTR_ENABLE         EIMSK */
+#define USB_INTR_ENABLE_BIT     INT1
+/* #define USB_INTR_PENDING        EIFR */
+#define USB_INTR_PENDING_BIT    INTF1
+#define USB_INTR_VECTOR         INT1_vect
+
+#endif /* __usbconfig_h_included__ */

--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -80,6 +80,14 @@ ifeq ($(strip $(SLEEP_LED_ENABLE)), yes)
     TMK_COMMON_DEFS += -DNO_SUSPEND_POWER_DOWN
 endif
 
+ifeq ($(strip $(NO_UART)), yes)
+    TMK_COMMON_DEFS += -DNO_UART
+endif
+
+ifeq ($(strip $(NO_SUSPEND_POWER_DOWN)), yes)
+    TMK_COMMON_DEFS += -DNO_SUSPEND_POWER_DOWN
+endif
+
 ifeq ($(strip $(BACKLIGHT_ENABLE)), yes)
     TMK_COMMON_SRC += $(COMMON_DIR)/backlight.c
     TMK_COMMON_DEFS += -DBACKLIGHT_ENABLE

--- a/tmk_core/common/avr/bootloader.c
+++ b/tmk_core/common/avr/bootloader.c
@@ -90,8 +90,10 @@ void bootloader_jump(void) {
             _delay_ms(5);
         #endif
 
-        #ifdef EEPROM_BOOTLOADER_START
-            eeprom_write_byte((uint8_t *)EEPROM_BOOTLOADER_START, 0x00);
+        #ifdef BOOTLOADHID_BOOTLOADER
+            // force bootloadHID to stay in bootloader mode, so that it waits
+            // for a new firmware to be flashed
+            eeprom_write_byte((uint8_t *)1, 0x00);
         #endif
 
         // watchdog reset

--- a/tmk_core/common/avr/bootloader.c
+++ b/tmk_core/common/avr/bootloader.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <avr/io.h>
+#include <avr/eeprom.h>
 #include <avr/interrupt.h>
 #include <avr/wdt.h>
 #include <util/delay.h>
@@ -89,6 +90,10 @@ void bootloader_jump(void) {
             _delay_ms(5);
         #endif
 
+        #ifdef EEPROM_BOOTLOADER_START
+            eeprom_write_byte((uint8_t *)EEPROM_BOOTLOADER_START, 0x00);
+        #endif
+
         // watchdog reset
         reset_key = BOOTLOADER_RESET_KEY;
         wdt_enable(WDTO_250MS);
@@ -113,6 +118,11 @@ void bootloader_jump(void) {
 
     #endif
 }
+
+#ifdef __AVR_ATmega32A__
+// MCUSR is actually called MCUCSR in ATmega32A
+#define MCUSR MCUCSR
+#endif
 
 /* this runs before main() */
 void bootloader_jump_after_watchdog_reset(void) __attribute__ ((used, naked, section (".init3")));

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -65,7 +65,6 @@ static uint8_t wdt_timeout = 0;
 
 static void power_down(uint8_t wdto)
 {
-#ifndef __AVR_ATmega32A__
 #ifdef PROTOCOL_LUFA
     if (USB_DeviceState == DEVICE_STATE_Configured) return;
 #endif
@@ -100,7 +99,6 @@ static void power_down(uint8_t wdto)
 
     // Disable watchdog after sleep
     wdt_disable();
-#endif
 }
 #endif
 

--- a/tmk_core/common/avr/suspend.c
+++ b/tmk_core/common/avr/suspend.c
@@ -65,6 +65,7 @@ static uint8_t wdt_timeout = 0;
 
 static void power_down(uint8_t wdto)
 {
+#ifndef __AVR_ATmega32A__
 #ifdef PROTOCOL_LUFA
     if (USB_DeviceState == DEVICE_STATE_Configured) return;
 #endif
@@ -99,6 +100,7 @@ static void power_down(uint8_t wdto)
 
     // Disable watchdog after sleep
     wdt_disable();
+#endif
 }
 #endif
 

--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -235,8 +235,10 @@ static void print_status(void)
     print("\n\t- Status -\n");
 
     print_val_hex8(host_keyboard_leds());
+#ifndef PROTOCOL_VUSB
     print_val_hex8(keyboard_protocol);
     print_val_hex8(keyboard_idle);
+#endif
 #ifdef NKRO_ENABLE
     print_val_hex8(keymap_config.nkro);
 #endif

--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -236,6 +236,7 @@ static void print_status(void)
 
     print_val_hex8(host_keyboard_leds());
 #ifndef PROTOCOL_VUSB
+    // these aren't set on the V-USB protocol, so we just ignore them for now
     print_val_hex8(keyboard_protocol);
     print_val_hex8(keyboard_idle);
 #endif

--- a/tmk_core/protocol/vusb.mk
+++ b/tmk_core/protocol/vusb.mk
@@ -2,7 +2,7 @@ VUSB_DIR = protocol/vusb
 
 OPT_DEFS += -DPROTOCOL_VUSB
 
-SRC +=	$(VUSB_DIR)/main.c \
+SRC += $(VUSB_DIR)/main.c \
 	$(VUSB_DIR)/vusb.c \
 	$(VUSB_DIR)/usbdrv/usbdrv.c \
 	$(VUSB_DIR)/usbdrv/usbdrvasm.S \
@@ -16,6 +16,7 @@ SRC +=	$(COMMON_DIR)/sendchar_uart.c \
 	$(COMMON_DIR)/uart.c
 endif
 
-
 # Search Path
-VPATH += $(TMK_DIR)/protocol/vusb:$(TMK_DIR)/protocol/vusb/usbdrv
+#VPATH += $(TMK_PATH)/$(VUSB_DIR)
+VPATH += $(TMK_PATH)/$(VUSB_DIR)
+VPATH += $(TMK_PATH)/$(VUSB_DIR)/usbdrv

--- a/tmk_core/protocol/vusb.mk
+++ b/tmk_core/protocol/vusb.mk
@@ -2,7 +2,7 @@ VUSB_DIR = protocol/vusb
 
 OPT_DEFS += -DPROTOCOL_VUSB
 
-SRC += $(VUSB_DIR)/main.c \
+SRC +=	$(VUSB_DIR)/main.c \
 	$(VUSB_DIR)/vusb.c \
 	$(VUSB_DIR)/usbdrv/usbdrv.c \
 	$(VUSB_DIR)/usbdrv/usbdrvasm.S \
@@ -16,7 +16,7 @@ SRC +=	$(COMMON_DIR)/sendchar_uart.c \
 	$(COMMON_DIR)/uart.c
 endif
 
+
 # Search Path
-#VPATH += $(TMK_PATH)/$(VUSB_DIR)
 VPATH += $(TMK_PATH)/$(VUSB_DIR)
 VPATH += $(TMK_PATH)/$(VUSB_DIR)/usbdrv

--- a/tmk_core/protocol/vusb/main.c
+++ b/tmk_core/protocol/vusb/main.c
@@ -48,8 +48,12 @@ int main(void)
     uint16_t last_timer = timer_read();
 #endif
 
+#ifdef CLKPR
+    // avoid unintentional changes of clock frequency in devices that have a
+    // clock prescaler
     CLKPR = 0x80, CLKPR = 0;
-#ifndef PS2_USE_USART
+#endif
+#ifndef NO_UART
     uart_init(UART_BAUD_RATE);
 #endif
 

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -15,6 +15,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <avr/eeprom.h>
+#include <avr/wdt.h>
 #include <stdint.h>
 #include "usbdrv.h"
 #include "usbconfig.h"
@@ -24,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "debug.h"
 #include "host_driver.h"
 #include "vusb.h"
+#include "bootloader.h"
 
 
 static uint8_t vusb_keyboard_leds = 0;
@@ -163,6 +166,7 @@ static struct {
     uint16_t        len;
     enum {
         NONE,
+        BOOTLOADER,
         SET_LED
     }               kind;
 } last_req;
@@ -193,6 +197,11 @@ usbRequest_t    *rq = (void *)data;
                 debug("SET_LED: ");
                 last_req.kind = SET_LED;
                 last_req.len = rq->wLength.word;
+#ifdef BOOTLOADER_SIZE
+            } else if(rq->wValue.word == 0x0301) {
+                last_req.kind = BOOTLOADER;
+                last_req.len = rq->wLength.word;
+#endif
             }
             return USB_NO_MSG; // to get data in usbFunctionWrite
         } else {
@@ -218,6 +227,11 @@ uchar usbFunctionWrite(uchar *data, uchar len)
             debug("\n");
             vusb_keyboard_leds = data[0];
             last_req.len = 0;
+            return 1;
+            break;
+        case BOOTLOADER:
+            usbDeviceDisconnect();
+            bootloader_jump();
             return 1;
             break;
         case NONE:
@@ -266,7 +280,7 @@ const PROGMEM uchar keyboard_hid_report[] = {
     0x95, 0x06,          //   Report Count (6),
     0x75, 0x08,          //   Report Size (8),
     0x15, 0x00,          //   Logical Minimum (0),
-    0x25, 0xFF, 0x00     //   Logical Maximum(255),
+    0x25, 0xFF, 0x00,    //   Logical Maximum(255),
     0x05, 0x07,          //   Usage Page (Key Codes),
     0x19, 0x00,          //   Usage Minimum (0),
     0x29, 0xFF,          //   Usage Maximum (255),
@@ -336,7 +350,7 @@ const PROGMEM uchar mouse_hid_report[] = {
     0xa1, 0x01,                    // COLLECTION (Application)
     0x85, REPORT_ID_SYSTEM,        //   REPORT_ID (2)
     0x15, 0x01,                    //   LOGICAL_MINIMUM (0x1)
-    0x25, 0xb7, 0x00               //   LOGICAL_MAXIMUM (0xb7)
+    0x25, 0xb7, 0x00,              //   LOGICAL_MAXIMUM (0xb7)
     0x19, 0x01,                    //   USAGE_MINIMUM (0x1)
     0x29, 0xb7,                    //   USAGE_MAXIMUM (0xb7)
     0x75, 0x10,                    //   REPORT_SIZE (16)
@@ -481,11 +495,11 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq)
             /* interface index */
             switch (rq->wIndex.word) {
                 case 0:
-                    usbMsgPtr = keyboard_hid_report;
+                    usbMsgPtr = (unsigned char *)keyboard_hid_report;
                     len = sizeof(keyboard_hid_report);
                     break;
                 case 1:
-                    usbMsgPtr = mouse_hid_report;
+                    usbMsgPtr = (unsigned char *)mouse_hid_report;
                     len = sizeof(mouse_hid_report);
                     break;
             }


### PR DESCRIPTION
This adds support for ps2avrGB / winkeyless.kr boards, using the V-USB protocol of the TMK firmware.

I had to make a few changes to `tmk_core` in order to get this working. To name a few:

1. Small changes to the Makefiles so that the V-USB protocol works again.
2. Added support for building with the `NO_UART` and `NO_SUSPEND_POWER_DOWN` options, since it made QMK a bit easier to build for the atmega32a these boards use.
3. Small changes to `tmk_core/common/avr/timer.c`. The atmega32a uses different register for some of the timers, so that file now has a few forks in order to support this microcontroller.
4. Added support for rebooting the board to the bootloader through software. This was done by [mimicking what the ps2avrGB firmware does](https://github.com/showjean/ps2avrU/blob/master/firmware/ps2avrGB/vusb.c#L533), where V-USB can receive a request from the computer to send it back to the bootloader. This means a few changes to `tmk_core/protocol/vusb/vusb.c`. I also fixed a few compiling warnings on that file.

For now, the backlight of the ps2avrGB boards isn't supported yet. Going to put that as a separate pull request. Also, there's a bug where the V-USB protocol isn't waking up the computer correctly, I'll fix that separately as well.

This resolves #959