### PR TITLE
Let's Split: More code cleanup

### DIFF
--- a/keyboards/lets_split/rev1/config.h
+++ b/keyboards/lets_split/rev1/config.h
@@ -41,17 +41,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define CATERINA_BOOTLOADER
 
-// #define USE_I2C
-// Use serial if not using I2C
-/*#ifndef USE_I2C
-#  define USE_SERIAL
-#endif
-
-// #define EE_HANDS
-
-#define I2C_MASTER_LEFT*/
-// #define I2C_MASTER_RIGHT
-
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 

--- a/keyboards/lets_split/rev2/config.h
+++ b/keyboards/lets_split/rev2/config.h
@@ -40,18 +40,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define CATERINA_BOOTLOADER
 
-// #define USE_I2C
-
-// Use serial if not using I2C
-/*#ifndef USE_I2C
-#  define USE_SERIAL
-#endif
-
-// #define EE_HANDS
-
-#define I2C_MASTER_LEFT*/
-// #define I2C_MASTER_RIGHT
-
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 


### PR DESCRIPTION
Missed a few commented out vestigal defines in revx/config.h that had
been moved to keymap/serial and i2c.